### PR TITLE
v0.2: ContentSource trait, programmable panes, persistent layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ Thumbs.db
 *.profdata
 lcov.info
 tarpaulin-report.html
+
+# Test/runtime artifacts
+tests/evidence/
+logs/
+outputs/
+.claude/runtime/
+.claude/settings.json

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,12 @@
 use crate::config::Config;
 use crate::keys::{self, Action, Mode};
+use crate::layouts;
 use crate::pane::PaneManager;
 use crate::session_picker::SessionPicker;
+use crate::source::command::CommandSource;
+use crate::source::local_tmux::LocalTmuxSource;
+use crate::source::tail::TailSource;
+use crate::source::{self, NewPaneRequest, PaneSpec};
 use crate::tmux;
 use crate::ui;
 use anyhow::Result;
@@ -32,14 +37,52 @@ impl App {
         }
     }
 
-    pub fn attach_session(&mut self, name: &str, owned: bool) {
-        self.pane_manager.add(name.to_string(), owned);
+    pub fn add_local_tmux(&mut self, name: &str, owned: bool) {
+        let source = if owned {
+            // Already created externally
+            LocalTmuxSource::attach(name.to_string())
+        } else {
+            LocalTmuxSource::attach(name.to_string())
+        };
+        self.pane_manager.add(Box::new(source));
     }
 
-    pub fn create_and_attach(&mut self, command: Option<&str>) -> Result<()> {
+    pub fn create_local_tmux(&mut self, command: Option<&str>) -> Result<()> {
         let name = tmux::generate_session_name();
-        tmux::create_session(&name, command)?;
-        self.pane_manager.add(name, true);
+        let source = LocalTmuxSource::create(name, command)?;
+        self.pane_manager.add(Box::new(source));
+        Ok(())
+    }
+
+    pub fn add_from_spec(&mut self, spec: &PaneSpec) -> Result<()> {
+        match spec {
+            PaneSpec::LocalTmux {
+                session,
+                create_cmd,
+            } => {
+                if tmux::session_exists(session) {
+                    self.pane_manager
+                        .add(Box::new(LocalTmuxSource::attach(session.clone())));
+                } else if let Some(cmd) = create_cmd {
+                    let source = LocalTmuxSource::create(session.clone(), Some(cmd))?;
+                    self.pane_manager.add(Box::new(source));
+                } else {
+                    let source = LocalTmuxSource::create(session.clone(), None)?;
+                    self.pane_manager.add(Box::new(source));
+                }
+            }
+            PaneSpec::Command {
+                command,
+                interval_ms,
+            } => {
+                let source = CommandSource::new(command.clone(), *interval_ms);
+                self.pane_manager.add(Box::new(source));
+            }
+            PaneSpec::Tail { path } => {
+                let source = TailSource::new(path)?;
+                self.pane_manager.add(Box::new(source));
+            }
+        }
         Ok(())
     }
 
@@ -47,20 +90,19 @@ impl App {
         match action {
             Action::Quit => self.should_quit = true,
             Action::AddPane => {
-                self.create_and_attach(None)?;
+                self.create_local_tmux(None)?;
             }
             Action::DropPane => {
-                if let Some(pane) = self.pane_manager.remove_focused() {
-                    if pane.owned {
-                        let _ = tmux::kill_session(&pane.session_name);
-                    }
-                }
+                // Pane::drop() calls source.cleanup()
+                self.pane_manager.remove_focused();
             }
             Action::FocusNext => self.pane_manager.focus_next(),
             Action::FocusPrev => self.pane_manager.focus_prev(),
             Action::EnterPaneMode => {
-                if self.pane_manager.focused().is_some() {
-                    self.mode = Mode::PaneFocused;
+                if let Some(pane) = self.pane_manager.focused() {
+                    if pane.is_interactive() {
+                        self.mode = Mode::PaneFocused;
+                    }
                 }
             }
             Action::ExitPaneMode => {
@@ -75,7 +117,8 @@ impl App {
             Action::PickerConfirm => {
                 if let Some(session) = self.picker.confirm() {
                     let name = session.name.clone();
-                    self.pane_manager.add(name, false);
+                    self.pane_manager
+                        .add(Box::new(LocalTmuxSource::attach(name)));
                 }
                 self.mode = Mode::Normal;
             }
@@ -84,12 +127,12 @@ impl App {
             }
             Action::RunBinding(cmd) => {
                 let name = tmux::generate_session_name();
-                tmux::create_session(&name, Some(&cmd))?;
-                self.pane_manager.add(name, true);
+                let source = LocalTmuxSource::create(name, Some(&cmd))?;
+                self.pane_manager.add(Box::new(source));
             }
             Action::SendKeys(keys) => {
-                if let Some(pane) = self.pane_manager.focused() {
-                    let _ = tmux::send_keys(&pane.session_name, &keys);
+                if let Some(pane) = self.pane_manager.focused_mut() {
+                    let _ = pane.source.send_keys(&keys);
                 }
             }
         }
@@ -97,7 +140,13 @@ impl App {
     }
 }
 
-pub fn run(config: Config, initial_sessions: Vec<String>, new_commands: Vec<String>) -> Result<()> {
+pub fn run(
+    config: Config,
+    initial_sessions: Vec<String>,
+    new_commands: Vec<String>,
+    layout: Option<String>,
+    save_layout: Option<String>,
+) -> Result<()> {
     // Setup terminal
     terminal::enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
@@ -106,30 +155,49 @@ pub fn run(config: Config, initial_sessions: Vec<String>, new_commands: Vec<Stri
 
     let mut app = App::new(config);
 
-    // Attach initial sessions
-    for name in &initial_sessions {
-        if tmux::session_exists(name) {
-            app.attach_session(name, false);
-        } else {
-            eprintln!("warning: tmux session '{}' not found, skipping", name);
+    // Load layout if specified
+    if let Some(layout_name) = &layout {
+        let spec = layouts::load(layout_name)?;
+        for pane_spec in &spec.panes {
+            app.add_from_spec(pane_spec)?;
         }
-    }
+    } else {
+        // Attach initial sessions
+        for name in &initial_sessions {
+            if tmux::session_exists(name) {
+                app.add_local_tmux(name, false);
+            }
+        }
 
-    // Create sessions for new commands
-    for cmd in &new_commands {
-        app.create_and_attach(Some(cmd))?;
-    }
+        // Create panes for new commands (supports watch:/tail: prefixes)
+        for cmd in &new_commands {
+            match source::parse_new_arg(cmd) {
+                NewPaneRequest::TmuxCommand { command } => {
+                    app.create_local_tmux(Some(&command))?;
+                }
+                NewPaneRequest::Command {
+                    command,
+                    interval_ms,
+                } => {
+                    let source = CommandSource::new(command, interval_ms);
+                    app.pane_manager.add(Box::new(source));
+                }
+                NewPaneRequest::Tail { path } => {
+                    let source = TailSource::new(&path)?;
+                    app.pane_manager.add(Box::new(source));
+                }
+            }
+        }
 
-    // If no panes, open session picker or create a default
-    if app.pane_manager.is_empty() {
-        let sessions = tmux::list_sessions()?;
-        if sessions.is_empty() {
-            // Create a default session
-            app.create_and_attach(None)?;
-        } else {
-            // Open picker
-            app.picker.refresh()?;
-            app.mode = Mode::SessionPicker;
+        // If no panes, open session picker or create a default
+        if app.pane_manager.is_empty() {
+            let sessions = tmux::list_sessions()?;
+            if sessions.is_empty() {
+                app.create_local_tmux(None)?;
+            } else {
+                app.picker.refresh()?;
+                app.mode = Mode::SessionPicker;
+            }
         }
     }
 
@@ -151,11 +219,10 @@ pub fn run(config: Config, initial_sessions: Vec<String>, new_commands: Vec<Stri
             );
             for (i, pane) in app.pane_manager.panes_mut().iter_mut().enumerate() {
                 if let Some(rect) = rects.get(i) {
-                    // Inner area (minus borders)
                     let w = rect.width.saturating_sub(2);
                     let h = rect.height.saturating_sub(2);
                     if w > 0 && h > 0 {
-                        if let Ok(content) = tmux::capture_pane(&pane.session_name, w, h) {
+                        if let Ok(content) = pane.source.capture(w, h) {
                             pane.content = content;
                         }
                     }
@@ -178,6 +245,20 @@ pub fn run(config: Config, initial_sessions: Vec<String>, new_commands: Vec<Stri
                 }
             }
         }
+    }
+
+    // Save layout if requested
+    if let Some(layout_name) = save_layout {
+        let specs: Vec<PaneSpec> = app
+            .pane_manager
+            .panes()
+            .iter()
+            .map(|p| p.source.to_spec())
+            .collect();
+        layouts::save(&layouts::LayoutSpec {
+            name: layout_name,
+            panes: specs,
+        })?;
     }
 
     // Cleanup

--- a/src/layouts.rs
+++ b/src/layouts.rs
@@ -1,0 +1,49 @@
+use crate::source::PaneSpec;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LayoutSpec {
+    pub name: String,
+    #[serde(rename = "pane")]
+    pub panes: Vec<PaneSpec>,
+}
+
+fn layouts_dir() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("tmuch")
+        .join("layouts")
+}
+
+pub fn load(name: &str) -> Result<LayoutSpec> {
+    let path = layouts_dir().join(format!("{}.toml", name));
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("Layout '{}' not found at {}", name, path.display()))?;
+    toml::from_str(&content).with_context(|| format!("Failed to parse layout '{}'", name))
+}
+
+pub fn save(spec: &LayoutSpec) -> Result<()> {
+    let dir = layouts_dir();
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}.toml", spec.name));
+    let content = toml::to_string_pretty(spec)?;
+    std::fs::write(&path, content)?;
+    eprintln!("Layout saved to {}", path.display());
+    Ok(())
+}
+
+pub fn list() -> Vec<String> {
+    let dir = layouts_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.strip_suffix(".toml").map(|s| s.to_string())
+        })
+        .collect()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ mod config;
 mod consts;
 mod keys;
 mod layout;
+mod layouts;
 mod pane;
 mod self_update;
 mod session_picker;
+mod source;
 mod tmux;
 mod ui;
 mod update_check;
@@ -22,13 +24,21 @@ struct Cli {
     #[arg()]
     sessions: Vec<String>,
 
-    /// Create a new tmux session running this command
+    /// Create a new pane (prefix: watch:cmd:ms, tail:path, or plain tmux command)
     #[arg(short = 'n', long = "new", value_name = "COMMAND")]
     new_commands: Vec<String>,
 
     /// Override a command binding (e.g., --bind 1="top")
     #[arg(short = 'b', long = "bind", value_name = "KEY=CMD")]
     binds: Vec<String>,
+
+    /// Load a named layout
+    #[arg(short = 'l', long = "layout", value_name = "NAME")]
+    layout: Option<String>,
+
+    /// Save current layout on exit
+    #[arg(long = "save-layout", value_name = "NAME")]
+    save_layout: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -36,14 +46,29 @@ enum Commands {
     /// Update tmuch to the latest version from GitHub Releases
     #[command(alias = "self-update")]
     Update,
+
+    /// List available saved layouts
+    Layouts,
 }
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     // Handle subcommands
-    if let Some(Commands::Update) = cli.command {
-        return self_update::handle_self_update();
+    match &cli.command {
+        Some(Commands::Update) => return self_update::handle_self_update(),
+        Some(Commands::Layouts) => {
+            let names = layouts::list();
+            if names.is_empty() {
+                eprintln!("No saved layouts. Use --save-layout NAME to save one.");
+            } else {
+                for name in names {
+                    println!("{}", name);
+                }
+            }
+            return Ok(());
+        }
+        None => {}
     }
 
     // Non-blocking update check (background, cached)
@@ -60,5 +85,11 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    app::run(config, cli.sessions, cli.new_commands)
+    app::run(
+        config,
+        cli.sessions,
+        cli.new_commands,
+        cli.layout,
+        cli.save_layout,
+    )
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1,8 +1,35 @@
+use crate::source::ContentSource;
+
 pub struct Pane {
-    pub session_name: String,
+    pub source: Box<dyn ContentSource>,
     pub content: String,
-    /// If true, we created this session and should kill it on drop
-    pub owned: bool,
+}
+
+impl Pane {
+    pub fn new(source: Box<dyn ContentSource>) -> Self {
+        Self {
+            source,
+            content: String::new(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.source.name()
+    }
+
+    pub fn source_label(&self) -> &str {
+        self.source.source_label()
+    }
+
+    pub fn is_interactive(&self) -> bool {
+        self.source.is_interactive()
+    }
+}
+
+impl Drop for Pane {
+    fn drop(&mut self) {
+        self.source.cleanup();
+    }
 }
 
 pub struct PaneManager {
@@ -18,13 +45,8 @@ impl PaneManager {
         }
     }
 
-    pub fn add(&mut self, session_name: String, owned: bool) {
-        self.panes.push(Pane {
-            session_name,
-            content: String::new(),
-            owned,
-        });
-        // Focus the newly added pane
+    pub fn add(&mut self, source: Box<dyn ContentSource>) {
+        self.panes.push(Pane::new(source));
         self.focused = self.panes.len() - 1;
     }
 
@@ -41,6 +63,10 @@ impl PaneManager {
 
     pub fn focused(&self) -> Option<&Pane> {
         self.panes.get(self.focused)
+    }
+
+    pub fn focused_mut(&mut self) -> Option<&mut Pane> {
+        self.panes.get_mut(self.focused)
     }
 
     pub fn focused_index(&self) -> usize {

--- a/src/source/command.rs
+++ b/src/source/command.rs
@@ -1,0 +1,93 @@
+use super::{ContentSource, PaneSpec};
+use anyhow::Result;
+use std::time::{Duration, Instant};
+
+/// Runs a command periodically and displays its output.
+pub struct CommandSource {
+    command: String,
+    interval: Duration,
+    last_run: Option<Instant>,
+    latest_output: String,
+    display_name: String,
+}
+
+impl CommandSource {
+    pub fn new(command: String, interval_ms: u64) -> Self {
+        // Derive a short display name from the command
+        let display_name = command
+            .split_whitespace()
+            .next()
+            .unwrap_or(&command)
+            .rsplit('/')
+            .next()
+            .unwrap_or(&command)
+            .to_string();
+
+        Self {
+            command,
+            interval: Duration::from_millis(interval_ms),
+            last_run: None,
+            latest_output: String::new(),
+            display_name,
+        }
+    }
+
+    fn should_refresh(&self) -> bool {
+        match self.last_run {
+            None => true,
+            Some(t) => t.elapsed() >= self.interval,
+        }
+    }
+
+    fn refresh(&mut self) {
+        let result = std::process::Command::new("sh")
+            .args(["-c", &self.command])
+            .output();
+
+        match result {
+            Ok(output) => {
+                self.latest_output = String::from_utf8_lossy(&output.stdout).to_string();
+                if !output.stderr.is_empty() {
+                    self.latest_output
+                        .push_str(&String::from_utf8_lossy(&output.stderr));
+                }
+            }
+            Err(e) => {
+                self.latest_output = format!("Error: {}", e);
+            }
+        }
+        self.last_run = Some(Instant::now());
+    }
+}
+
+impl ContentSource for CommandSource {
+    fn capture(&mut self, _width: u16, _height: u16) -> Result<String> {
+        if self.should_refresh() {
+            self.refresh();
+        }
+        Ok(self.latest_output.clone())
+    }
+
+    fn send_keys(&mut self, _keys: &str) -> Result<()> {
+        Ok(()) // not interactive
+    }
+
+    fn name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn source_label(&self) -> &str {
+        "cmd"
+    }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+
+    fn to_spec(&self) -> PaneSpec {
+        PaneSpec::Command {
+            command: self.command.clone(),
+            interval_ms: self.interval.as_millis() as u64,
+        }
+    }
+}

--- a/src/source/local_tmux.rs
+++ b/src/source/local_tmux.rs
@@ -1,0 +1,63 @@
+use super::{ContentSource, PaneSpec};
+use crate::tmux;
+use anyhow::Result;
+
+pub struct LocalTmuxSource {
+    session_name: String,
+    owned: bool,
+    create_cmd: Option<String>,
+}
+
+impl LocalTmuxSource {
+    pub fn attach(session_name: String) -> Self {
+        Self {
+            session_name,
+            owned: false,
+            create_cmd: None,
+        }
+    }
+
+    pub fn create(session_name: String, command: Option<&str>) -> Result<Self> {
+        tmux::create_session(&session_name, command)?;
+        Ok(Self {
+            create_cmd: command.map(|s| s.to_string()),
+            session_name,
+            owned: true,
+        })
+    }
+}
+
+impl ContentSource for LocalTmuxSource {
+    fn capture(&mut self, width: u16, height: u16) -> Result<String> {
+        tmux::capture_pane(&self.session_name, width, height)
+    }
+
+    fn send_keys(&mut self, keys: &str) -> Result<()> {
+        tmux::send_keys(&self.session_name, keys)
+    }
+
+    fn name(&self) -> &str {
+        &self.session_name
+    }
+
+    fn source_label(&self) -> &str {
+        "local"
+    }
+
+    fn is_interactive(&self) -> bool {
+        true
+    }
+
+    fn cleanup(&mut self) {
+        if self.owned {
+            let _ = tmux::kill_session(&self.session_name);
+        }
+    }
+
+    fn to_spec(&self) -> PaneSpec {
+        PaneSpec::LocalTmux {
+            session: self.session_name.clone(),
+            create_cmd: self.create_cmd.clone(),
+        }
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,0 +1,88 @@
+pub mod command;
+pub mod local_tmux;
+pub mod tail;
+
+use anyhow::Result;
+
+/// A content source that can provide terminal output for a pane.
+pub trait ContentSource: Send {
+    /// Capture current visible content, sized to fit the given dimensions.
+    fn capture(&mut self, width: u16, height: u16) -> Result<String>;
+
+    /// Send keystrokes to the source (for interactive sources).
+    fn send_keys(&mut self, keys: &str) -> Result<()>;
+
+    /// Display name for the pane title.
+    fn name(&self) -> &str;
+
+    /// Source type label (e.g., "local", "ssh:host", "cmd", "tail").
+    fn source_label(&self) -> &str;
+
+    /// Whether this source accepts keyboard input.
+    fn is_interactive(&self) -> bool;
+
+    /// Clean up resources when the pane is dropped.
+    fn cleanup(&mut self) {}
+
+    /// Serialize back to a layout spec for saving.
+    fn to_spec(&self) -> PaneSpec;
+}
+
+/// Specification for recreating a pane from a layout file.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum PaneSpec {
+    #[serde(rename = "local")]
+    LocalTmux {
+        session: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        create_cmd: Option<String>,
+    },
+    #[serde(rename = "command")]
+    Command {
+        command: String,
+        #[serde(default = "default_interval")]
+        interval_ms: u64,
+    },
+    #[serde(rename = "tail")]
+    Tail { path: String },
+}
+
+fn default_interval() -> u64 {
+    5000
+}
+
+/// Parse a `-n` argument into a content source.
+/// Supports prefixes: `watch:cmd:interval`, `tail:path`, or plain tmux command.
+pub fn parse_new_arg(arg: &str) -> NewPaneRequest {
+    if let Some(rest) = arg.strip_prefix("tail:") {
+        NewPaneRequest::Tail {
+            path: rest.to_string(),
+        }
+    } else if let Some(rest) = arg.strip_prefix("watch:") {
+        // Format: watch:command:interval_ms
+        let parts: Vec<&str> = rest.rsplitn(2, ':').collect();
+        if parts.len() == 2 {
+            if let Ok(interval) = parts[0].parse::<u64>() {
+                return NewPaneRequest::Command {
+                    command: parts[1].to_string(),
+                    interval_ms: interval,
+                };
+            }
+        }
+        NewPaneRequest::Command {
+            command: rest.to_string(),
+            interval_ms: 5000,
+        }
+    } else {
+        NewPaneRequest::TmuxCommand {
+            command: arg.to_string(),
+        }
+    }
+}
+
+pub enum NewPaneRequest {
+    TmuxCommand { command: String },
+    Command { command: String, interval_ms: u64 },
+    Tail { path: String },
+}

--- a/src/source/tail.rs
+++ b/src/source/tail.rs
@@ -1,0 +1,106 @@
+use super::{ContentSource, PaneSpec};
+use anyhow::{Context, Result};
+use std::collections::VecDeque;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+const MAX_LINES: usize = 1000;
+
+/// Tails a file using a background `tail -f` process.
+pub struct TailSource {
+    path: PathBuf,
+    buffer: Arc<Mutex<VecDeque<String>>>,
+    child: Option<Child>,
+}
+
+impl TailSource {
+    pub fn new(path: &str) -> Result<Self> {
+        let path = PathBuf::from(path);
+        let buffer = Arc::new(Mutex::new(VecDeque::with_capacity(MAX_LINES)));
+
+        let mut child = Command::new("tail")
+            .args(["-n", "50", "-f"])
+            .arg(&path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Failed to spawn tail process")?;
+
+        let stdout = child.stdout.take().context("No stdout from tail")?;
+        let buf_clone = Arc::clone(&buffer);
+
+        std::thread::spawn(move || {
+            let reader = std::io::BufReader::new(stdout);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                let mut buf = buf_clone.lock().unwrap();
+                if buf.len() >= MAX_LINES {
+                    buf.pop_front();
+                }
+                buf.push_back(line);
+            }
+        });
+
+        Ok(Self {
+            path,
+            buffer,
+            child: Some(child),
+        })
+    }
+}
+
+impl ContentSource for TailSource {
+    fn capture(&mut self, _width: u16, height: u16) -> Result<String> {
+        let buf = self.buffer.lock().unwrap();
+        let lines: Vec<&str> = buf
+            .iter()
+            .rev()
+            .take(height as usize)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .map(|s| s.as_str())
+            .collect();
+        Ok(lines.join("\n"))
+    }
+
+    fn send_keys(&mut self, _keys: &str) -> Result<()> {
+        Ok(()) // not interactive
+    }
+
+    fn name(&self) -> &str {
+        self.path
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("tail")
+    }
+
+    fn source_label(&self) -> &str {
+        "tail"
+    }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(ref mut child) = self.child {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
+    fn to_spec(&self) -> PaneSpec {
+        PaneSpec::Tail {
+            path: self.path.to_string_lossy().to_string(),
+        }
+    }
+}
+
+impl Drop for TailSource {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -30,10 +30,13 @@ pub fn draw(frame: &mut Frame, app: &App) {
                 Color::DarkGray
             };
 
+            let label = pane.source_label();
             let title = if is_focused && app.mode == Mode::PaneFocused {
-                format!(" {} [ATTACHED] ", pane.session_name)
+                format!(" {} [ATTACHED] ", pane.name())
+            } else if label != "local" {
+                format!(" {} [{}] ", pane.name(), label)
             } else {
-                format!(" {} ", pane.session_name)
+                format!(" {} ", pane.name())
             };
 
             let block = Block::default()
@@ -73,7 +76,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             "[{}/{}] {}",
             app.pane_manager.focused_index() + 1,
             app.pane_manager.count(),
-            pane.session_name
+            pane.name()
         )
     } else {
         format!("[0/{}]", app.pane_manager.count())


### PR DESCRIPTION
## Summary

Introduces the `ContentSource` trait that decouples panes from tmux sessions, enabling programmable pane content and persistent layouts.

### New features
- **Programmable panes**: `watch:cmd:interval` and `tail:path` prefixes for `-n` flag
- **Persistent layouts**: `--layout NAME` / `--save-layout NAME` / `tmuch layouts`
- **Source labels**: Pane titles show `[cmd]`, `[tail]` for non-tmux sources

### Architecture
- `ContentSource` trait with `capture()`, `send_keys()`, `name()`, `source_label()`, `is_interactive()`, `cleanup()`, `to_spec()`
- `LocalTmuxSource` wraps existing tmux functions
- `CommandSource` runs periodic commands
- `TailSource` tails files via background thread
- Foundation for SSH remote sessions (next)

## Testing

- 23 unit tests pass
- 33 E2E assertions pass (existing tests unchanged)
- Manual E2E: `watch:date:1000` shows refreshing date with `[cmd]` label
- Manual E2E: `tail:/tmp/test.log` shows live-appended lines with `[tail]` label
- Manual E2E: `--save-layout` writes correct TOML, `--layout` loads it, `tmuch layouts` lists it

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)