### PR TITLE
Add azlin VM discovery and bastion tunnel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "azlin-azure"
+version = "2.6.24"
+source = "git+https://github.com/rysweet/azlin#caf371870acbfe6d66cf64e3f3c4e0b2a94e2a93"
+dependencies = [
+ "anyhow",
+ "azlin-core",
+ "chrono",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "wait-timeout",
+]
+
+[[package]]
 name = "azlin-core"
 version = "2.6.24"
 source = "git+https://github.com/rysweet/azlin#caf371870acbfe6d66cf64e3f3c4e0b2a94e2a93"
@@ -474,7 +492,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -655,7 +673,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -737,8 +755,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -789,6 +813,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
@@ -1152,6 +1191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1356,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1553,12 @@ dependencies = [
  "rand_core",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "poly1305"
@@ -1830,7 +1929,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.59.0",
 ]
 
@@ -2201,6 +2313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,10 +2380,13 @@ version = "0.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "azlin-azure",
+ "azlin-core",
  "azlin-ssh",
  "clap",
  "crossterm",
  "dirs",
+ "libc",
  "ratatui",
  "serde",
  "serde_json",
@@ -2474,10 +2602,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ serde_json = "1"
 dirs = "6"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "process"] }
 shellexpand = "3"
+libc = "0.2"
 
 # SSH via azlin-ssh (reuses production SSH pool, client, key management)
 # Uses git dep for CI; local dev can override with:
 #   [patch.'https://github.com/rysweet/azlin']
 #   azlin-ssh = { path = "../azlin/rust/crates/azlin-ssh" }
 azlin-ssh = { git = "https://github.com/rysweet/azlin" }
+azlin-azure = { git = "https://github.com/rysweet/azlin" }
+azlin-core = { git = "https://github.com/rysweet/azlin" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -174,11 +174,12 @@ impl App {
                 self.mode = Mode::Normal;
             }
             Action::OpenSessionPicker => {
-                if self.config.remote.is_empty() {
+                if self.config.remote.is_empty() && !self.config.azlin.enabled {
                     self.picker.refresh()?;
                 } else {
                     self.picker.refresh_with_remotes(
                         &self.config.remote,
+                        &self.config.azlin,
                         &self.ssh_pool,
                         &self.tokio_handle,
                     )?;

--- a/src/azlin_integration.rs
+++ b/src/azlin_integration.rs
@@ -1,0 +1,309 @@
+//! Integration with azlin for Azure VM discovery and bastion tunnels.
+//!
+//! Uses azlin-azure for VM listing and azlin-ssh for connections.
+//! Bastion tunnels managed via `az network bastion tunnel` subprocess
+//! with persistent registry at /tmp/azlin-tunnels/.
+
+use anyhow::{Context, Result};
+use azlin_azure::auth::AzureAuth;
+use azlin_azure::vm::VmManager;
+use azlin_core::models::{PowerState, VmInfo};
+use azlin_ssh::{SshConfig, SshPool};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::source::ssh_tmux::RemoteConfig;
+use crate::tmux::SessionInfo;
+
+const TUNNEL_REGISTRY_PATH: &str = "/tmp/azlin-tunnels/registry.json";
+const TUNNEL_PORT_START: u16 = 50200;
+
+/// Config section for azlin integration.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct AzlinConfig {
+    pub enabled: bool,
+    pub resource_group: Option<String>,
+}
+
+/// Discover running Azure VMs via azlin-azure (synchronous — uses az CLI).
+pub fn discover_vms(resource_group: Option<&str>) -> Result<Vec<VmInfo>> {
+    let auth = AzureAuth::new().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let vm_manager = VmManager::new(&auth);
+
+    let vms = if let Some(rg) = resource_group {
+        vm_manager
+            .list_vms(rg)
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    } else {
+        vm_manager
+            .list_all_vms()
+            .map_err(|e| anyhow::anyhow!("{}", e))?
+    };
+
+    Ok(vms
+        .into_iter()
+        .filter(|vm| matches!(vm.power_state, PowerState::Running))
+        .collect())
+}
+
+/// Convert a VmInfo to a RemoteConfig.
+/// For private VMs, creates a bastion tunnel and routes through localhost.
+pub fn vm_to_remote_config(vm: &VmInfo) -> Result<RemoteConfig> {
+    let user = vm
+        .admin_username
+        .clone()
+        .unwrap_or_else(|| "azureuser".to_string());
+
+    let key = resolve_ssh_key();
+
+    if let Some(ref public_ip) = vm.public_ip {
+        Ok(RemoteConfig {
+            name: vm.name.clone(),
+            host: public_ip.clone(),
+            user,
+            key,
+            port: 22,
+            poll_interval_ms: 500,
+        })
+    } else if vm.private_ip.is_some() {
+        let local_port =
+            get_or_create_bastion_tunnel(vm).context(format!("Bastion tunnel for {}", vm.name))?;
+
+        Ok(RemoteConfig {
+            name: vm.name.clone(),
+            host: "127.0.0.1".to_string(),
+            user,
+            key,
+            port: local_port,
+            poll_interval_ms: 500,
+        })
+    } else {
+        anyhow::bail!("VM '{}' has no IP", vm.name);
+    }
+}
+
+/// Discover tmux sessions on all reachable VMs.
+pub async fn discover_remote_sessions(
+    pool: &SshPool,
+    resource_group: Option<&str>,
+) -> Result<Vec<SessionInfo>> {
+    // VM discovery is synchronous (az CLI calls)
+    let vms = discover_vms(resource_group)?;
+    let mut sessions = Vec::new();
+
+    for vm in &vms {
+        let remote = match vm_to_remote_config(vm) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        let ssh_config = match to_ssh_config(&remote) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let result = match pool.get_or_connect(&ssh_config).await {
+            Ok(mut client) => {
+                let res = client
+                    .execute("tmux list-sessions -F '#{session_name}' 2>/dev/null || true")
+                    .await;
+                pool.release(client).await;
+                res
+            }
+            Err(_) => continue,
+        };
+
+        if let Ok(result) = result {
+            for name in result.stdout.lines().filter(|l| !l.is_empty()) {
+                sessions.push(SessionInfo {
+                    name: name.to_string(),
+                    attached: false,
+                    windows: 0,
+                    host: Some(vm.name.clone()),
+                });
+            }
+        }
+    }
+
+    Ok(sessions)
+}
+
+fn to_ssh_config(remote: &RemoteConfig) -> Result<SshConfig> {
+    let key_path = remote
+        .key
+        .as_ref()
+        .map(|p| PathBuf::from(shellexpand::tilde(p).as_ref()))
+        .or_else(resolve_ssh_key_path)
+        .context("No SSH key found")?;
+
+    let mut config = SshConfig::new(&remote.host, &remote.user, key_path);
+    config.port = remote.port;
+    Ok(config)
+}
+
+fn resolve_ssh_key() -> Option<String> {
+    resolve_ssh_key_path().map(|p| p.to_string_lossy().to_string())
+}
+
+fn resolve_ssh_key_path() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    for name in ["azlin_key", "id_rsa", "id_ed25519"] {
+        let path = home.join(".ssh").join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+// ---- Bastion Tunnel Management ----
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TunnelRegistryEntry {
+    vm_resource_id: String,
+    bastion_name: String,
+    resource_group: String,
+    local_port: u16,
+    pid: u32,
+    created_at: u64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct TunnelRegistry {
+    tunnels: HashMap<String, TunnelRegistryEntry>,
+}
+
+fn load_registry() -> TunnelRegistry {
+    std::fs::read_to_string(TUNNEL_REGISTRY_PATH)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_registry(registry: &TunnelRegistry) {
+    if let Some(parent) = std::path::Path::new(TUNNEL_REGISTRY_PATH).parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    if let Ok(json) = serde_json::to_string_pretty(registry) {
+        std::fs::write(TUNNEL_REGISTRY_PATH, json).ok();
+    }
+}
+
+fn is_process_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+fn build_vm_resource_id(vm: &VmInfo) -> Result<String> {
+    let output = std::process::Command::new("az")
+        .args(["account", "show", "--query", "id", "-o", "tsv"])
+        .output()
+        .context("Failed to get subscription ID")?;
+
+    let sub_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sub_id.is_empty() {
+        anyhow::bail!("No Azure subscription found — run `az login`");
+    }
+
+    Ok(format!(
+        "/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute/virtualMachines/{}",
+        sub_id, vm.resource_group, vm.name
+    ))
+}
+
+fn detect_bastion(resource_group: &str) -> Option<String> {
+    let output = std::process::Command::new("az")
+        .args([
+            "network",
+            "bastion",
+            "list",
+            "--resource-group",
+            resource_group,
+            "--query",
+            "[0].name",
+            "-o",
+            "tsv",
+        ])
+        .output()
+        .ok()?;
+
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+fn get_or_create_bastion_tunnel(vm: &VmInfo) -> Result<u16> {
+    let vm_resource_id = build_vm_resource_id(vm)?;
+
+    let mut registry = load_registry();
+
+    // Prune dead tunnels
+    registry
+        .tunnels
+        .retain(|_, entry| is_process_alive(entry.pid));
+
+    // Return existing if alive
+    if let Some(entry) = registry.tunnels.get(&vm_resource_id) {
+        save_registry(&registry);
+        return Ok(entry.local_port);
+    }
+
+    let bastion_name = detect_bastion(&vm.resource_group)
+        .ok_or_else(|| anyhow::anyhow!("No bastion host in RG {}", vm.resource_group))?;
+
+    let local_port = TUNNEL_PORT_START + registry.tunnels.len() as u16;
+
+    let child = std::process::Command::new("az")
+        .args([
+            "network",
+            "bastion",
+            "tunnel",
+            "--name",
+            &bastion_name,
+            "--resource-group",
+            &vm.resource_group,
+            "--target-resource-id",
+            &vm_resource_id,
+            "--resource-port",
+            "22",
+            "--port",
+            &local_port.to_string(),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .context("Failed to spawn bastion tunnel")?;
+
+    let pid = child.id();
+
+    // Wait for tunnel to establish
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
+    if !is_process_alive(pid) {
+        anyhow::bail!("Bastion tunnel process died");
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    registry.tunnels.insert(
+        vm_resource_id.clone(),
+        TunnelRegistryEntry {
+            vm_resource_id,
+            bastion_name,
+            resource_group: vm.resource_group.clone(),
+            local_port,
+            pid,
+            created_at: now,
+        },
+    );
+
+    save_registry(&registry);
+    Ok(local_port)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::azlin_integration::AzlinConfig;
 use crate::source::ssh_tmux::RemoteConfig;
 use anyhow::Result;
 use serde::Deserialize;
@@ -12,6 +13,8 @@ pub struct Config {
     pub display: DisplayConfig,
     #[serde(default)]
     pub remote: Vec<RemoteConfig>,
+    #[serde(default)]
+    pub azlin: AzlinConfig,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod azlin_integration;
 mod config;
 mod consts;
 mod keys;

--- a/src/session_picker.rs
+++ b/src/session_picker.rs
@@ -1,3 +1,4 @@
+use crate::azlin_integration::{self, AzlinConfig};
 use crate::source::ssh_tmux::RemoteConfig;
 use crate::tmux::{self, SessionInfo};
 use anyhow::Result;
@@ -19,47 +20,56 @@ impl SessionPicker {
 
     pub fn refresh(&mut self) -> Result<()> {
         self.sessions = tmux::list_sessions()?;
-        if self.selected >= self.sessions.len() && !self.sessions.is_empty() {
-            self.selected = self.sessions.len() - 1;
-        }
+        self.clamp_selected();
         Ok(())
     }
 
-    /// Refresh including remote sessions from configured hosts.
+    /// Refresh including remote sessions from configured hosts and azlin VMs.
     pub fn refresh_with_remotes(
         &mut self,
         remotes: &[RemoteConfig],
+        azlin_config: &AzlinConfig,
         pool: &Arc<SshPool>,
         rt: &tokio::runtime::Handle,
     ) -> Result<()> {
         // Local sessions first
         self.sessions = tmux::list_sessions()?;
 
-        // Remote sessions
+        // Configured remote hosts
         for remote in remotes {
             let remote = remote.clone();
             let result = rt.block_on(crate::source::ssh_tmux::list_remote_sessions(pool, &remote));
-            match result {
-                Ok(names) => {
-                    for name in names {
-                        self.sessions.push(SessionInfo {
-                            name,
-                            attached: false,
-                            windows: 0,
-                            host: Some(remote.name.clone()),
-                        });
-                    }
-                }
-                Err(_) => {
-                    // Skip unreachable hosts silently in the picker
+            if let Ok(names) = result {
+                for name in names {
+                    self.sessions.push(SessionInfo {
+                        name,
+                        attached: false,
+                        windows: 0,
+                        host: Some(remote.name.clone()),
+                    });
                 }
             }
         }
 
+        // Azlin VM discovery (if enabled)
+        if azlin_config.enabled {
+            let result = rt.block_on(azlin_integration::discover_remote_sessions(
+                pool,
+                azlin_config.resource_group.as_deref(),
+            ));
+            if let Ok(remote_sessions) = result {
+                self.sessions.extend(remote_sessions);
+            }
+        }
+
+        self.clamp_selected();
+        Ok(())
+    }
+
+    fn clamp_selected(&mut self) {
         if self.selected >= self.sessions.len() && !self.sessions.is_empty() {
             self.selected = self.sessions.len() - 1;
         }
-        Ok(())
     }
 
     pub fn select_next(&mut self) {


### PR DESCRIPTION
## Summary

Integrates with azlin-azure and azlin-core for Azure VM discovery and bastion tunnel management.

### What's new
- **VM discovery**: `discover_vms()` lists running Azure VMs via `az CLI` (with 60-min cache)
- **Auto-config**: `vm_to_remote_config()` resolves VM → SSH config (public IP direct or bastion tunnel)
- **Bastion tunnels**: spawns `az network bastion tunnel`, persists registry at `/tmp/azlin-tunnels/registry.json`, reuses existing tunnels, prunes dead processes
- **Session picker**: discovers tmux sessions on azlin VMs when `[azlin] enabled = true`
- **Config**: `[azlin]` section with `enabled` and optional `resource_group`

### Dependencies
- `azlin-azure` (git dep) — VM listing, caching
- `azlin-core` (git dep) — VmInfo model, PowerState enum
- `libc` — process liveness check for bastion tunnels

### Testing
- 23 unit tests pass
- 33 E2E tests pass (zero regressions)
- clippy clean with -D warnings

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)