### PR TITLE
Add Python/PyPI wrapper for uvx/pipx distribution

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "tmuch"
+version = "0.2.0"
+description = "TUI tmux multiplexer - display multiple tmux sessions in a single terminal"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+authors = [{ name = "Ryan Sweet" }]
+keywords = ["tmux", "terminal", "multiplexer", "tui", "ratatui"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Topic :: System :: Shells",
+    "Topic :: Terminals :: Terminal Emulators/X Terminals",
+]
+
+[project.urls]
+Homepage = "https://github.com/rysweet/tmuch"
+Repository = "https://github.com/rysweet/tmuch"
+
+[project.scripts]
+tmuch = "tmuch:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["python/tmuch"]

--- a/python/tmuch/__init__.py
+++ b/python/tmuch/__init__.py
@@ -1,0 +1,12 @@
+"""tmuch - TUI tmux multiplexer.
+
+Install: uvx tmuch
+        pipx install tmuch
+        pip install tmuch
+"""
+
+__version__ = "0.2.0"
+
+from tmuch.cli import main
+
+__all__ = ["main"]

--- a/python/tmuch/__main__.py
+++ b/python/tmuch/__main__.py
@@ -1,0 +1,3 @@
+"""Allow running as `python -m tmuch`."""
+from tmuch import main
+main()

--- a/python/tmuch/cli.py
+++ b/python/tmuch/cli.py
@@ -1,0 +1,125 @@
+"""Download and execute the tmuch Rust binary from GitHub Releases."""
+
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+GITHUB_REPO = "rysweet/tmuch"
+VERSION = "0.2.0"
+
+
+def _platform_suffix() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "linux":
+        if machine in ("x86_64", "amd64"):
+            return "linux-x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux-aarch64"
+    elif system == "darwin":
+        if machine in ("x86_64", "amd64"):
+            return "macos-x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "macos-aarch64"
+
+    raise RuntimeError(f"Unsupported platform: {system}-{machine}")
+
+
+def _bin_dir() -> Path:
+    """Where to cache the downloaded binary."""
+    cache = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache / "tmuch" / "bin"
+
+
+def _ensure_binary() -> Path:
+    """Download the tmuch binary if not already cached."""
+    bin_dir = _bin_dir()
+    binary = bin_dir / "tmuch"
+
+    # Check if we already have the right version
+    if binary.exists():
+        try:
+            result = subprocess.run(
+                [str(binary), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if f"tmuch {VERSION}" in result.stdout:
+                return binary
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Download from GitHub Releases
+    suffix = _platform_suffix()
+    asset_name = f"tmuch-{suffix}.tar.gz"
+    url = f"https://github.com/{GITHUB_REPO}/releases/download/v{VERSION}/{asset_name}"
+
+    print(f"Downloading tmuch v{VERSION} for {suffix}...", file=sys.stderr)
+
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        archive_path = Path(tmp) / asset_name
+
+        # Download
+        try:
+            urllib.request.urlretrieve(url, archive_path)
+        except Exception as e:
+            # Try gh CLI as fallback
+            try:
+                subprocess.run(
+                    [
+                        "gh",
+                        "release",
+                        "download",
+                        f"v{VERSION}",
+                        "--repo",
+                        GITHUB_REPO,
+                        "--pattern",
+                        f"*{suffix}*",
+                        "--dir",
+                        tmp,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                raise RuntimeError(
+                    f"Failed to download tmuch: {e}\n"
+                    f"URL: {url}\n"
+                    f"Try: gh release download v{VERSION} --repo {GITHUB_REPO}"
+                ) from e
+
+        # Extract
+        with tarfile.open(archive_path) as tar:
+            tar.extractall(tmp)
+
+        # Find the binary
+        for name in os.listdir(tmp):
+            if name.startswith("tmuch") and not name.endswith(".tar.gz"):
+                src = Path(tmp) / name
+                if src.is_file():
+                    shutil.copy2(src, binary)
+                    binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+                    print(
+                        f"Installed tmuch v{VERSION} to {binary}",
+                        file=sys.stderr,
+                    )
+                    return binary
+
+    raise RuntimeError("Binary not found in downloaded archive")
+
+
+def main():
+    """Entry point: ensure binary exists and exec into it."""
+    binary = _ensure_binary()
+    os.execv(str(binary), [str(binary)] + sys.argv[1:])


### PR DESCRIPTION
## Summary

Thin Python package that wraps the Rust binary for distribution via uvx/pipx/pip.

### How it works
- `uvx tmuch` installs the Python package, which on first run downloads the platform-specific binary from GitHub Releases
- Binary is cached at `~/.cache/tmuch/bin/tmuch` and reused on subsequent runs
- Version check ensures cached binary matches package version
- Falls back to `gh release download` if direct URL fails

### Usage (after PyPI publish)
```bash
uvx tmuch                    # run directly
uvx tmuch azlin              # discover all VMs
pipx install tmuch           # install permanently
```

### Tested
- `uv build` produces valid wheel
- `uvx --from ./dist/tmuch-0.2.0-py3-none-any.whl tmuch --version` → downloads binary, prints `tmuch 0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)