### PR TITLE
Fix #14: stop resizing remote tmux windows, restore on cleanup

### DIFF
--- a/src/source/ssh_subprocess.rs
+++ b/src/source/ssh_subprocess.rs
@@ -17,7 +17,6 @@ pub struct SshSubprocessSource {
     latest_content: Arc<Mutex<String>>,
     error: Arc<Mutex<Option<String>>>,
     shutdown: Arc<Mutex<bool>>,
-    dimensions: Arc<Mutex<(u16, u16)>>,
     display_name: String,
     label: String,
 }
@@ -34,14 +33,12 @@ impl SshSubprocessSource {
         let latest_content = Arc::new(Mutex::new(String::new()));
         let error = Arc::new(Mutex::new(None));
         let shutdown = Arc::new(Mutex::new(false));
-        let dimensions = Arc::new(Mutex::new((80u16, 24u16)));
         let display_name = format!("{}:{}", name, session);
         let label = format!("ssh:{}", name);
 
         let content_clone = Arc::clone(&latest_content);
         let error_clone = Arc::clone(&error);
         let shutdown_clone = Arc::clone(&shutdown);
-        let dims_clone = Arc::clone(&dimensions);
         let host_clone = host.clone();
         let user_clone = user.clone();
         let session_clone = session.clone();
@@ -54,10 +51,11 @@ impl SshSubprocessSource {
                     break;
                 }
 
-                let (w, h) = *dims_clone.lock().unwrap();
+                // Capture without resizing — resizing remote windows causes
+                // them to stay tiny after tmuch exits (issue #14)
                 let cmd = format!(
-                    "tmux resize-window -t {} -x {} -y {} 2>/dev/null; tmux capture-pane -p -e -t {} 2>/dev/null || echo '[session not found]'",
-                    shell_escape(&session_clone), w, h, shell_escape(&session_clone)
+                    "tmux capture-pane -p -e -t {} 2>/dev/null || echo '[session not found]'",
+                    shell_escape(&session_clone)
                 );
 
                 let result = run_ssh_command(&host_clone, &user_clone, port, &cmd);
@@ -84,7 +82,6 @@ impl SshSubprocessSource {
             latest_content,
             error,
             shutdown,
-            dimensions,
             display_name,
             label,
         }
@@ -144,9 +141,7 @@ fn shell_escape(s: &str) -> String {
 }
 
 impl ContentSource for SshSubprocessSource {
-    fn capture(&mut self, width: u16, height: u16) -> Result<String> {
-        *self.dimensions.lock().unwrap() = (width, height);
-
+    fn capture(&mut self, _width: u16, _height: u16) -> Result<String> {
         if let Some(err) = self.error.lock().unwrap().as_ref() {
             return Ok(format!("[{}]\n\n{}\n\nRetrying...", self.display_name, err));
         }
@@ -185,6 +180,13 @@ impl ContentSource for SshSubprocessSource {
 
     fn cleanup(&mut self) {
         *self.shutdown.lock().unwrap() = true;
+
+        // Restore remote window to automatic size
+        let cmd = format!(
+            "tmux resize-window -t {} -A 2>/dev/null; true",
+            shell_escape(&self.session)
+        );
+        let _ = run_ssh_command(&self.host, &self.user, self.port, &cmd);
     }
 
     fn to_spec(&self) -> PaneSpec {

--- a/src/source/ssh_tmux.rs
+++ b/src/source/ssh_tmux.rs
@@ -122,7 +122,6 @@ pub struct SshTmuxSource {
     latest_content: Arc<Mutex<String>>,
     error: Arc<Mutex<Option<String>>>,
     shutdown: Arc<Mutex<bool>>,
-    dimensions: Arc<Mutex<(u16, u16)>>,
     display_name: String,
     label: String,
 }
@@ -132,14 +131,12 @@ impl SshTmuxSource {
         let latest_content = Arc::new(Mutex::new(String::new()));
         let error = Arc::new(Mutex::new(None));
         let shutdown = Arc::new(Mutex::new(false));
-        let dimensions = Arc::new(Mutex::new((80u16, 24u16)));
         let display_name = format!("{}:{}", remote.name, session);
         let label = format!("ssh:{}", remote.name);
 
         let content_clone = Arc::clone(&latest_content);
         let error_clone = Arc::clone(&error);
         let shutdown_clone = Arc::clone(&shutdown);
-        let dimensions_clone = Arc::clone(&dimensions);
         let remote_clone = remote.clone();
         let session_clone = session.clone();
         let pool_clone = Arc::clone(&pool);
@@ -153,20 +150,13 @@ impl SshTmuxSource {
                     break;
                 }
 
-                // Read current dimensions for remote resize
-                let (w, h) = *dimensions_clone.lock().unwrap();
-
-                // Resize remote tmux window before capture
-                let resize_cmd = format!(
-                    "tmux resize-window -t {} -x {} -y {} 2>/dev/null; \
-                     tmux capture-pane -p -e -t {} 2>/dev/null || echo '[session not found]'",
-                    shell_escape(&session_clone),
-                    w,
-                    h,
+                // Capture without resizing (issue #14)
+                let cmd = format!(
+                    "tmux capture-pane -p -e -t {} 2>/dev/null || echo '[session not found]'",
                     shell_escape(&session_clone)
                 );
 
-                match ssh_exec(&pool_clone, &remote_clone, &resize_cmd).await {
+                match ssh_exec(&pool_clone, &remote_clone, &cmd).await {
                     Ok(output) => {
                         *content_clone.lock().unwrap() = output;
                         *error_clone.lock().unwrap() = None;
@@ -193,7 +183,6 @@ impl SshTmuxSource {
             latest_content,
             error,
             shutdown,
-            dimensions,
             display_name,
             label,
         }
@@ -201,10 +190,7 @@ impl SshTmuxSource {
 }
 
 impl ContentSource for SshTmuxSource {
-    fn capture(&mut self, width: u16, height: u16) -> Result<String> {
-        // Update dimensions for background task to use on next poll
-        *self.dimensions.lock().unwrap() = (width, height);
-
+    fn capture(&mut self, _width: u16, _height: u16) -> Result<String> {
         if let Some(err) = self.error.lock().unwrap().as_ref() {
             return Ok(format!("[{}]\n\n{}", self.display_name, err));
         }


### PR DESCRIPTION
Stops tmuch from shrinking remote tmux windows. On cleanup, restores automatic sizing.

- Remove `tmux resize-window` from SSH capture commands
- `cleanup()` sends `tmux resize-window -A` to restore remote windows
- Remove unused dimensions fields

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)