### PR TITLE
Add mouse click-to-focus and visual polish

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,10 +12,11 @@ use crate::source::{self, NewPaneRequest, PaneSpec};
 use crate::tmux;
 use crate::ui;
 use anyhow::Result;
-use crossterm::event::{self, Event};
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, MouseEventKind};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::ExecutableCommand;
 use ratatui::backend::CrosstermBackend;
+use ratatui::layout::Rect;
 use ratatui::Terminal;
 use std::io;
 use std::time::Duration;
@@ -75,6 +76,7 @@ pub struct App {
     pub picker: SessionPicker,
     pub should_quit: bool,
     pub command_editor: Option<CommandEditorState>,
+    pub pane_rects: Vec<Rect>,
 }
 
 impl App {
@@ -86,6 +88,7 @@ impl App {
             picker: SessionPicker::new(),
             should_quit: false,
             command_editor: None,
+            pane_rects: Vec::new(),
         }
     }
 
@@ -343,6 +346,9 @@ impl App {
                 self.command_editor = None;
                 self.mode = Mode::Normal;
             }
+            Action::FocusPane(idx) => {
+                self.pane_manager.focus_index(idx);
+            }
         }
         Ok(())
     }
@@ -394,6 +400,7 @@ pub fn run_azlin(resource_group: Option<String>) -> Result<()> {
     // Launch TUI with all discovered sessions
     terminal::enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
+    io::stdout().execute(EnableMouseCapture)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
@@ -427,13 +434,9 @@ pub fn run_azlin(resource_group: Option<String>) -> Result<()> {
             // Reserve 2 rows: top hint bar + bottom status bar
             let rects = crate::layout::compute(
                 pane_count,
-                ratatui::layout::Rect::new(
-                    0,
-                    1,
-                    term_size.width,
-                    term_size.height.saturating_sub(2),
-                ),
+                Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2)),
             );
+            app.pane_rects = rects.clone();
             for (i, pane) in app.pane_manager.panes_mut().iter_mut().enumerate() {
                 if let Some(rect) = rects.get(i) {
                     let w = rect.width.saturating_sub(2);
@@ -454,15 +457,35 @@ pub fn run_azlin(resource_group: Option<String>) -> Result<()> {
         }
 
         if event::poll(poll_duration)? {
-            if let Event::Key(key) = event::read()? {
-                if let Some(action) = keys::handle(key, &app.mode, &app.config) {
-                    app.handle_action(action)?;
+            match event::read()? {
+                Event::Key(key) => {
+                    if let Some(action) = keys::handle(key, &app.mode, &app.config) {
+                        app.handle_action(action)?;
+                    }
                 }
+                Event::Mouse(mouse) => {
+                    if let MouseEventKind::Down(crossterm::event::MouseButton::Left) = mouse.kind {
+                        let col = mouse.column;
+                        let row = mouse.row;
+                        for (idx, rect) in app.pane_rects.iter().enumerate() {
+                            if col >= rect.x
+                                && col < rect.x + rect.width
+                                && row >= rect.y
+                                && row < rect.y + rect.height
+                            {
+                                app.handle_action(Action::FocusPane(idx))?;
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }
 
     terminal::disable_raw_mode()?;
+    io::stdout().execute(DisableMouseCapture)?;
     io::stdout().execute(LeaveAlternateScreen)?;
     Ok(())
 }
@@ -477,6 +500,7 @@ pub fn run(
     // Setup terminal
     terminal::enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
+    io::stdout().execute(EnableMouseCapture)?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
@@ -547,13 +571,9 @@ pub fn run(
             // Reserve 2 rows: top hint bar + bottom status bar
             let rects = crate::layout::compute(
                 pane_count,
-                ratatui::layout::Rect::new(
-                    0,
-                    1,
-                    term_size.width,
-                    term_size.height.saturating_sub(2),
-                ),
+                Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2)),
             );
+            app.pane_rects = rects.clone();
             for (i, pane) in app.pane_manager.panes_mut().iter_mut().enumerate() {
                 if let Some(rect) = rects.get(i) {
                     let w = rect.width.saturating_sub(2);
@@ -576,10 +596,29 @@ pub fn run(
 
         // Handle events
         if event::poll(poll_duration)? {
-            if let Event::Key(key) = event::read()? {
-                if let Some(action) = keys::handle(key, &app.mode, &app.config) {
-                    app.handle_action(action)?;
+            match event::read()? {
+                Event::Key(key) => {
+                    if let Some(action) = keys::handle(key, &app.mode, &app.config) {
+                        app.handle_action(action)?;
+                    }
                 }
+                Event::Mouse(mouse) => {
+                    if let MouseEventKind::Down(crossterm::event::MouseButton::Left) = mouse.kind {
+                        let col = mouse.column;
+                        let row = mouse.row;
+                        for (idx, rect) in app.pane_rects.iter().enumerate() {
+                            if col >= rect.x
+                                && col < rect.x + rect.width
+                                && row >= rect.y
+                                && row < rect.y + rect.height
+                            {
+                                app.handle_action(Action::FocusPane(idx))?;
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -600,6 +639,7 @@ pub fn run(
 
     // Cleanup
     terminal::disable_raw_mode()?;
+    io::stdout().execute(DisableMouseCapture)?;
     io::stdout().execute(LeaveAlternateScreen)?;
 
     Ok(())

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -33,6 +33,7 @@ pub enum Action {
     EditorDown,
     EditorDelete,
     EditorClose,
+    FocusPane(usize),
 }
 
 pub fn handle(event: KeyEvent, mode: &Mode, config: &Config) -> Option<Action> {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -89,6 +89,12 @@ impl PaneManager {
         }
     }
 
+    pub fn focus_index(&mut self, idx: usize) {
+        if idx < self.panes.len() {
+            self.focused = idx;
+        }
+    }
+
     pub fn panes(&self) -> &[Pane] {
         &self.panes
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,9 +3,9 @@ use crate::keys::Mode;
 use crate::layout;
 use ansi_to_tui::IntoText;
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph};
 use ratatui::Frame;
 
 pub fn draw(frame: &mut Frame, app: &App) {
@@ -32,27 +32,49 @@ pub fn draw(frame: &mut Frame, app: &App) {
     for (i, pane) in app.pane_manager.panes().iter().enumerate() {
         if let Some(&rect) = rects.get(i) {
             let is_focused = i == app.pane_manager.focused_index();
+            let is_remote = pane.source_label() != "local";
+
             let border_color = if is_focused {
                 match app.mode {
                     Mode::PaneFocused => Color::Green,
                     _ => Color::Yellow,
                 }
+            } else if is_remote {
+                Color::Rgb(40, 60, 80)
             } else {
-                Color::DarkGray
+                Color::Rgb(60, 60, 60)
             };
 
             let label = pane.source_label();
-            let title = if is_focused && app.mode == Mode::PaneFocused {
-                format!(" {} [ATTACHED] ", pane.name())
-            } else if label != "local" {
-                format!(" {} [{}] ", pane.name(), label)
+            let title_spans = if is_focused && app.mode == Mode::PaneFocused {
+                vec![Span::styled(
+                    format!(" \u{25b6} {} [ATTACHED] ", pane.name()),
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                )]
             } else {
-                format!(" {} ", pane.name())
+                let name_style = if is_focused {
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::Rgb(120, 120, 120))
+                };
+                if label != "local" {
+                    vec![Span::styled(
+                        format!(" {} [{}] ", pane.name(), label),
+                        name_style,
+                    )]
+                } else {
+                    vec![Span::styled(format!(" {} ", pane.name()), name_style)]
+                }
             };
 
             let block = Block::default()
-                .title(title)
+                .title(Line::from(title_spans))
                 .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(border_color));
 
             let inner = block.inner(rect);
@@ -80,22 +102,95 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 }
 
+fn hint_separator() -> Span<'static> {
+    Span::styled(" \u{2502} ", Style::default().fg(Color::Rgb(60, 60, 60)))
+}
+
+fn hint_key(key: &'static str) -> Span<'static> {
+    Span::styled(
+        key,
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn hint_label(label: &'static str) -> Span<'static> {
+    Span::styled(label, Style::default().fg(Color::DarkGray))
+}
+
 fn draw_hints_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let hints = match app.mode {
-        Mode::Normal => {
-            " q Quit \u{2502} ^A Add \u{2502} ^D Drop \u{2502} ^S Sessions \u{2502} ^Z Azlin \u{2502} ^E Edit Cmds \u{2502} Tab Next \u{2502} Enter Focus \u{2502} 1-9 Bindings"
-        }
-        Mode::PaneFocused => " Esc Unfocus \u{2502} All keys forwarded to session",
-        Mode::SessionPicker => {
-            " \u{2191}\u{2193}/jk Navigate \u{2502} Enter Select \u{2502} a Add All \u{2502} z Scan Azlin \u{2502} Esc Cancel"
-        }
-        Mode::CommandEditor => {
-            " \u{2191}\u{2193} Navigate \u{2502} d Delete \u{2502} Esc Close \u{2502} Edit ~/.config/tmuch/config.toml to add bindings"
-        }
+    let spans = match app.mode {
+        Mode::Normal => vec![
+            Span::raw(" "),
+            hint_key("q"),
+            hint_label(" Quit"),
+            hint_separator(),
+            hint_key("^A"),
+            hint_label(" Add"),
+            hint_separator(),
+            hint_key("^D"),
+            hint_label(" Drop"),
+            hint_separator(),
+            hint_key("^S"),
+            hint_label(" Sessions"),
+            hint_separator(),
+            hint_key("^Z"),
+            hint_label(" Azlin"),
+            hint_separator(),
+            hint_key("^E"),
+            hint_label(" Edit Cmds"),
+            hint_separator(),
+            hint_key("Tab"),
+            hint_label(" Next"),
+            hint_separator(),
+            hint_key("Enter"),
+            hint_label(" Focus"),
+            hint_separator(),
+            hint_key("1-9"),
+            hint_label(" Bindings"),
+        ],
+        Mode::PaneFocused => vec![
+            Span::raw(" "),
+            hint_key("Esc"),
+            hint_label(" Unfocus"),
+            hint_separator(),
+            hint_label("All keys forwarded to session"),
+        ],
+        Mode::SessionPicker => vec![
+            Span::raw(" "),
+            hint_key("\u{2191}\u{2193}/jk"),
+            hint_label(" Navigate"),
+            hint_separator(),
+            hint_key("Enter"),
+            hint_label(" Select"),
+            hint_separator(),
+            hint_key("a"),
+            hint_label(" Add All"),
+            hint_separator(),
+            hint_key("z"),
+            hint_label(" Scan Azlin"),
+            hint_separator(),
+            hint_key("Esc"),
+            hint_label(" Cancel"),
+        ],
+        Mode::CommandEditor => vec![
+            Span::raw(" "),
+            hint_key("\u{2191}\u{2193}"),
+            hint_label(" Navigate"),
+            hint_separator(),
+            hint_key("d"),
+            hint_label(" Delete"),
+            hint_separator(),
+            hint_key("Esc"),
+            hint_label(" Close"),
+            hint_separator(),
+            hint_label("Edit ~/.config/tmuch/config.toml to add bindings"),
+        ],
     };
 
-    let line = Line::from(Span::styled(hints, Style::default().fg(Color::DarkGray)));
-    let bar = Paragraph::new(line).style(Style::default());
+    let line = Line::from(spans);
+    let bar = Paragraph::new(line).style(Style::default().bg(Color::Rgb(30, 30, 30)));
     frame.render_widget(bar, area);
 }
 
@@ -118,15 +213,35 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         format!("[0/{}]", app.pane_manager.count())
     };
 
-    let line = Line::from(vec![
+    let version_tag = concat!("tmuch v", env!("CARGO_PKG_VERSION"), " ");
+    let version_len = version_tag.len() as u16;
+
+    // Left side spans
+    let left_spans = vec![
         Span::styled(
             format!(" {} ", mode_str),
             Style::default().fg(Color::Black).bg(Color::Cyan),
         ),
         Span::raw(" "),
-        Span::styled(pane_info, Style::default().fg(Color::White)),
-    ]);
+        Span::styled(pane_info.clone(), Style::default().fg(Color::White)),
+    ];
 
+    // Compute padding for right-alignment
+    let left_len = (mode_str.len() + 2) + 1 + pane_info.len();
+    let padding = if area.width as usize > left_len + version_len as usize {
+        area.width as usize - left_len - version_len as usize
+    } else {
+        1
+    };
+
+    let mut spans = left_spans;
+    spans.push(Span::raw(" ".repeat(padding)));
+    spans.push(Span::styled(
+        version_tag,
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let line = Line::from(spans);
     let bar = Paragraph::new(line).style(Style::default().bg(Color::Black));
     frame.render_widget(bar, area);
 }
@@ -158,7 +273,9 @@ fn draw_session_picker(frame: &mut Frame, app: &App, area: Rect) {
                 None => String::new(),
             };
             let style = if i == app.picker.selected {
-                Style::default().fg(Color::Yellow)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else if s.host.is_some() {
                 Style::default().fg(Color::Cyan)
             } else {
@@ -170,8 +287,9 @@ fn draw_session_picker(frame: &mut Frame, app: &App, area: Rect) {
 
     let list = List::new(items).block(
         Block::default()
-            .title(" tmux sessions ")
+            .title(Span::styled(" Sessions ", Style::default().fg(Color::Cyan)))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Cyan)),
     );
 
@@ -207,7 +325,9 @@ fn draw_command_editor(frame: &mut Frame, app: &App, area: Rect) {
                 "  "
             };
             let style = if i == editor.selected {
-                Style::default().fg(Color::Yellow)
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
@@ -221,8 +341,12 @@ fn draw_command_editor(frame: &mut Frame, app: &App, area: Rect) {
 
     let list = List::new(items).block(
         Block::default()
-            .title(" Command Bindings ")
+            .title(Span::styled(
+                " Command Bindings ",
+                Style::default().fg(Color::Cyan),
+            ))
             .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Cyan)),
     );
 

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -29,7 +29,7 @@ cargo build --release 2>&1 | tail -1
 # Cleanup any leftover test sessions
 cleanup() {
     tmux kill-session -t "$TEST_SESSION" 2>/dev/null || true
-    for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^e2e-'); do
+    for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^e2e-pane-'); do
         tmux kill-session -t "$s" 2>/dev/null || true
     done
     for s in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^tmuch-'); do
@@ -215,7 +215,7 @@ if true; then
     send C-s  # Open picker
     sleep 1
     capture "test5-picker-open"
-    assert_screen_contains "tmux sessions" "picker overlay shows title" && pass || fail
+    assert_screen_contains "Sessions" "picker overlay shows title" && pass || fail
     assert_screen_contains "PICKER" "status bar shows PICKER mode" && pass || fail
 
     send j  # Navigate down
@@ -328,7 +328,7 @@ if true; then
     sleep 1
     capture "test10-first-launch"
     # Should open session picker since sessions exist
-    assert_screen_contains "tmux sessions" "first launch opens session picker" && pass || fail
+    assert_screen_contains "Sessions" "first launch opens session picker" && pass || fail
 
     send Enter  # Select first session
     sleep 2


### PR DESCRIPTION
## Summary
- **Mouse click-to-focus**: Enable mouse capture on startup; clicking a pane sets it as focused via new `FocusPane(usize)` action and stored `pane_rects` for hit-testing
- **Rounded borders**: All blocks (panes, session picker, command editor) now use `BorderType::Rounded`
- **Better color palette**: Focused pane Yellow/Green borders with bold titles, unfocused Rgb(60,60,60), remote unfocused Rgb(40,60,80), styled hints bar with Cyan bold keys on dark background, right-aligned version tag in status bar

## Test plan
- [x] `cargo fmt --all` -- clean
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo test` -- 23/23 pass
- [x] `cargo build --release` -- success
- [x] `bash tests/run-e2e.sh` -- 43/43 pass (updated session picker title assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)