### PR TITLE
Add widget rendering, IPC, and border drag resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,11 +1136,12 @@ dependencies = [
 
 [[package]]
 name = "tmuch"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
  "azlin-azure",
+ "chrono",
  "clap",
  "clap_complete",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 dirs = "6"
 shellexpand = "3"
 libc = "0.2"
+chrono = { version = "0.4", features = ["clock"] }
 
 # Azure VM discovery (azlin-azure uses az CLI, no async needed)
 azlin-azure = { git = "https://github.com/rysweet/azlin" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,15 @@
 use crate::config::Config;
+use crate::ipc::{IpcCommand, IpcServer};
 use crate::keys::{self, Action, Mode};
 use crate::layout::{PaneId, SplitDirection};
 use crate::layouts;
 use crate::pane::PaneManager;
 use crate::session_picker::SessionPicker;
+use crate::source::clock::ClockSource;
 use crate::source::command::CommandSource;
 use crate::source::http::HttpSource;
 use crate::source::local_tmux::LocalTmuxSource;
+use crate::source::registry::PluginRegistry;
 use crate::source::ssh_subprocess::{RemoteConfig, SshSubprocessSource};
 use crate::source::tail::TailSource;
 use crate::source::{self, NewPaneRequest, PaneSpec};
@@ -21,6 +24,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::layout::Rect;
 use ratatui::Terminal;
 use std::io;
+use std::sync::mpsc;
 use std::time::Duration;
 
 /// State for the command editor overlay.
@@ -71,6 +75,16 @@ impl CommandEditorState {
     }
 }
 
+/// State for tracking border drag resize.
+pub struct DragState {
+    /// Path to the split node being dragged.
+    pub split_path: Vec<usize>,
+    /// Direction of the split being dragged.
+    pub direction: SplitDirection,
+    /// Area of the parent split node, used to compute ratios.
+    pub parent_area: Rect,
+}
+
 pub struct App {
     pub pane_manager: PaneManager,
     pub config: Config,
@@ -80,6 +94,8 @@ pub struct App {
     pub command_editor: Option<CommandEditorState>,
     pub pane_rects: Vec<(PaneId, Rect)>,
     pub theme: Theme,
+    pub plugin_registry: PluginRegistry,
+    pub drag_state: Option<DragState>,
 }
 
 impl App {
@@ -94,6 +110,8 @@ impl App {
             command_editor: None,
             pane_rects: Vec::new(),
             theme,
+            plugin_registry: PluginRegistry::new(),
+            drag_state: None,
         }
     }
 
@@ -140,6 +158,16 @@ impl App {
             PaneSpec::Http { url, interval_ms } => {
                 let source = HttpSource::new(url.clone(), *interval_ms);
                 self.pane_manager.add(Box::new(source));
+            }
+            PaneSpec::Plugin {
+                plugin_name,
+                config,
+            } => {
+                if let Some(source) = self.plugin_registry.create(plugin_name, config.clone()) {
+                    self.pane_manager.add(source);
+                } else {
+                    anyhow::bail!("Unknown plugin '{}'", plugin_name);
+                }
             }
             PaneSpec::Remote {
                 remote_name,
@@ -377,6 +405,158 @@ impl App {
         }
         Ok(())
     }
+
+    /// Handle an IPC command, returning a JSON response string.
+    pub fn handle_ipc(&mut self, cmd: IpcCommand) -> String {
+        match cmd {
+            IpcCommand::ListPanes => {
+                let panes: Vec<serde_json::Value> = self
+                    .pane_manager
+                    .panes()
+                    .iter()
+                    .map(|(id, p)| {
+                        serde_json::json!({
+                            "id": id,
+                            "name": p.name(),
+                            "source": p.source_label(),
+                        })
+                    })
+                    .collect();
+                serde_json::json!({ "ok": true, "panes": panes }).to_string()
+            }
+            IpcCommand::AddPane(spec) => match self.add_from_spec(&spec) {
+                Ok(()) => serde_json::json!({ "ok": true }).to_string(),
+                Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }).to_string(),
+            },
+            IpcCommand::RemovePane(id) => {
+                self.pane_manager.remove(id);
+                serde_json::json!({ "ok": true }).to_string()
+            }
+            IpcCommand::FocusPane(id) => {
+                self.pane_manager.focus_id(id);
+                serde_json::json!({ "ok": true }).to_string()
+            }
+            IpcCommand::Split { direction, spec } => {
+                let dir = if direction == "horizontal" {
+                    SplitDirection::Horizontal
+                } else {
+                    SplitDirection::Vertical
+                };
+                // Create the source from spec, then split
+                let result = match &spec {
+                    PaneSpec::LocalTmux {
+                        session,
+                        create_cmd,
+                    } => {
+                        if tmux::session_exists(session) {
+                            Ok(Box::new(LocalTmuxSource::attach(session.clone()))
+                                as Box<dyn crate::source::ContentSource>)
+                        } else {
+                            LocalTmuxSource::create(session.clone(), create_cmd.as_deref())
+                                .map(|s| Box::new(s) as Box<dyn crate::source::ContentSource>)
+                        }
+                    }
+                    PaneSpec::Command {
+                        command,
+                        interval_ms,
+                    } => Ok(Box::new(CommandSource::new(command.clone(), *interval_ms))
+                        as Box<dyn crate::source::ContentSource>),
+                    PaneSpec::Plugin {
+                        plugin_name,
+                        config,
+                    } => self
+                        .plugin_registry
+                        .create(plugin_name, config.clone())
+                        .ok_or_else(|| anyhow::anyhow!("Unknown plugin")),
+                    _ => Err(anyhow::anyhow!("Unsupported spec for split")),
+                };
+                match result {
+                    Ok(source) => {
+                        self.pane_manager.split_focused(dir, source);
+                        serde_json::json!({ "ok": true }).to_string()
+                    }
+                    Err(e) => {
+                        serde_json::json!({ "ok": false, "error": e.to_string() }).to_string()
+                    }
+                }
+            }
+            IpcCommand::Maximize(id) => {
+                self.pane_manager.focus_id(id);
+                self.pane_manager.toggle_maximize();
+                serde_json::json!({ "ok": true }).to_string()
+            }
+            IpcCommand::SendKeys { id, keys } => {
+                if let Some(pane) = self.pane_manager.get_mut(id) {
+                    let _ = pane.source.send_keys(&keys);
+                }
+                serde_json::json!({ "ok": true }).to_string()
+            }
+            IpcCommand::Quit => {
+                self.should_quit = true;
+                serde_json::json!({ "ok": true }).to_string()
+            }
+        }
+    }
+
+    /// Handle mouse-down for border drag detection.
+    pub fn handle_mouse_down(&mut self, col: u16, row: u16, main_area: Rect) {
+        // Check if click is on a split boundary for drag resize
+        if let Some(layout) = self.pane_manager.layout() {
+            if let Some(split_ref) = layout.find_split_at(col, row, main_area, 1) {
+                self.drag_state = Some(DragState {
+                    split_path: split_ref.path,
+                    direction: split_ref.direction,
+                    parent_area: split_ref.area,
+                });
+                return;
+            }
+        }
+
+        // Otherwise, focus the pane under cursor
+        for (id, rect) in &self.pane_rects {
+            if col >= rect.x
+                && col < rect.x + rect.width
+                && row >= rect.y
+                && row < rect.y + rect.height
+            {
+                self.pane_manager.focus_id(*id);
+                break;
+            }
+        }
+    }
+
+    /// Handle mouse drag for border resize.
+    pub fn handle_mouse_drag(&mut self, col: u16, row: u16) {
+        if let Some(ref drag) = self.drag_state {
+            let path = drag.split_path.clone();
+            let direction = drag.direction;
+            let parent_area = drag.parent_area;
+
+            let ratio = match direction {
+                SplitDirection::Vertical => {
+                    if parent_area.width == 0 {
+                        return;
+                    }
+                    let rel = col.saturating_sub(parent_area.x) as f32 / parent_area.width as f32;
+                    rel.clamp(0.1, 0.9)
+                }
+                SplitDirection::Horizontal => {
+                    if parent_area.height == 0 {
+                        return;
+                    }
+                    let rel = row.saturating_sub(parent_area.y) as f32 / parent_area.height as f32;
+                    rel.clamp(0.1, 0.9)
+                }
+            };
+
+            self.pane_manager.set_ratio_at(&path, ratio);
+        }
+    }
+
+    /// Handle mouse up — stop dragging.
+    pub fn handle_mouse_up(&mut self) {
+        self.drag_state = None;
+    }
 }
 
 /// Run azlin discovery: list all VMs and their tmux sessions, then launch TUI.
@@ -480,28 +660,26 @@ pub fn run_azlin(resource_group: Option<String>) -> Result<()> {
         }
 
         if event::poll(poll_duration)? {
+            let term_size = terminal.size()?;
+            let main_area = Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2));
             match event::read()? {
                 Event::Key(key) => {
                     if let Some(action) = keys::handle(key, &app.mode, &app.config) {
                         app.handle_action(action)?;
                     }
                 }
-                Event::Mouse(mouse) => {
-                    if let MouseEventKind::Down(crossterm::event::MouseButton::Left) = mouse.kind {
-                        let col = mouse.column;
-                        let row = mouse.row;
-                        for (id, rect) in &app.pane_rects {
-                            if col >= rect.x
-                                && col < rect.x + rect.width
-                                && row >= rect.y
-                                && row < rect.y + rect.height
-                            {
-                                app.pane_manager.focus_id(*id);
-                                break;
-                            }
-                        }
+                Event::Mouse(mouse) => match mouse.kind {
+                    MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_down(mouse.column, mouse.row, main_area);
                     }
-                }
+                    MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_drag(mouse.column, mouse.row);
+                    }
+                    MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_up();
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }
@@ -528,6 +706,10 @@ pub fn run(
     let mut terminal = Terminal::new(backend)?;
 
     let mut app = App::new(config);
+
+    // Start IPC server
+    let (ipc_tx, ipc_rx) = mpsc::channel();
+    let _ipc_server = IpcServer::start(ipc_tx).ok();
 
     // Load layout if specified
     if let Some(layout_name) = &layout {
@@ -568,6 +750,9 @@ pub fn run(
                 NewPaneRequest::Http { url, interval_ms } => {
                     let source = HttpSource::new(url, interval_ms);
                     app.pane_manager.add(Box::new(source));
+                }
+                NewPaneRequest::Clock => {
+                    app.pane_manager.add(Box::new(ClockSource));
                 }
             }
         }
@@ -630,30 +815,34 @@ pub fn run(
             break;
         }
 
+        // Handle IPC commands
+        while let Ok(msg) = ipc_rx.try_recv() {
+            let response = app.handle_ipc(msg.command);
+            let _ = msg.response_tx.send(response);
+        }
+
         // Handle events
         if event::poll(poll_duration)? {
+            let term_size = terminal.size()?;
+            let main_area = Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2));
             match event::read()? {
                 Event::Key(key) => {
                     if let Some(action) = keys::handle(key, &app.mode, &app.config) {
                         app.handle_action(action)?;
                     }
                 }
-                Event::Mouse(mouse) => {
-                    if let MouseEventKind::Down(crossterm::event::MouseButton::Left) = mouse.kind {
-                        let col = mouse.column;
-                        let row = mouse.row;
-                        for (id, rect) in &app.pane_rects {
-                            if col >= rect.x
-                                && col < rect.x + rect.width
-                                && row >= rect.y
-                                && row < rect.y + rect.height
-                            {
-                                app.pane_manager.focus_id(*id);
-                                break;
-                            }
-                        }
+                Event::Mouse(mouse) => match mouse.kind {
+                    MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_down(mouse.column, mouse.row, main_area);
                     }
-                }
+                    MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_drag(mouse.column, mouse.row);
+                    }
+                    MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+                        app.handle_mouse_up();
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,0 +1,212 @@
+use crate::source::PaneSpec;
+use anyhow::Result;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+/// Commands that can be sent via IPC.
+#[derive(Debug)]
+pub enum IpcCommand {
+    ListPanes,
+    AddPane(PaneSpec),
+    RemovePane(u32),
+    FocusPane(u32),
+    Split { direction: String, spec: PaneSpec },
+    Maximize(u32),
+    SendKeys { id: u32, keys: String },
+    Quit,
+}
+
+/// Response channel: the IPC thread sends commands and receives responses.
+pub struct IpcMessage {
+    pub command: IpcCommand,
+    pub response_tx: mpsc::Sender<String>,
+}
+
+pub struct IpcServer {
+    socket_path: PathBuf,
+}
+
+impl IpcServer {
+    /// Start the IPC server on a background thread.
+    /// Returns the server handle and the receiver for the main event loop.
+    pub fn start(tx: mpsc::Sender<IpcMessage>) -> Result<Self> {
+        let pid = std::process::id();
+        let socket_path = PathBuf::from(format!("/tmp/tmuch-{}.sock", pid));
+
+        // Remove stale socket
+        let _ = std::fs::remove_file(&socket_path);
+
+        let listener = UnixListener::bind(&socket_path)?;
+        listener.set_nonblocking(false)?;
+
+        let path_clone = socket_path.clone();
+        let tx_clone = tx;
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                let tx = tx_clone.clone();
+                std::thread::spawn(move || {
+                    let reader = BufReader::new(&stream);
+                    let mut writer = &stream;
+                    for line in reader.lines() {
+                        let Ok(line) = line else { break };
+                        let line = line.trim().to_string();
+                        if line.is_empty() {
+                            continue;
+                        }
+
+                        match parse_ipc_command(&line) {
+                            Ok(cmd) => {
+                                let (resp_tx, resp_rx) = mpsc::channel();
+                                let msg = IpcMessage {
+                                    command: cmd,
+                                    response_tx: resp_tx,
+                                };
+                                if tx.send(msg).is_err() {
+                                    break;
+                                }
+                                // Wait for response from the main thread
+                                let response = resp_rx
+                                    .recv_timeout(std::time::Duration::from_secs(5))
+                                    .unwrap_or_else(|_| {
+                                        r#"{"ok":false,"error":"timeout"}"#.to_string()
+                                    });
+                                let _ = writeln!(writer, "{}", response);
+                            }
+                            Err(e) => {
+                                let resp = serde_json::json!({
+                                    "ok": false,
+                                    "error": format!("parse error: {}", e)
+                                });
+                                let _ = writeln!(writer, "{}", resp);
+                            }
+                        }
+                    }
+                });
+            }
+            let _ = std::fs::remove_file(&path_clone);
+        });
+
+        Ok(Self { socket_path })
+    }
+
+    #[allow(dead_code)]
+    pub fn socket_path(&self) -> &PathBuf {
+        &self.socket_path
+    }
+}
+
+impl Drop for IpcServer {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+fn parse_ipc_command(json: &str) -> Result<IpcCommand> {
+    let v: serde_json::Value = serde_json::from_str(json)?;
+    let cmd_type = v
+        .get("command")
+        .and_then(|c| c.as_str())
+        .unwrap_or_default();
+
+    match cmd_type {
+        "list_panes" => Ok(IpcCommand::ListPanes),
+        "add_pane" => {
+            let spec: PaneSpec = serde_json::from_value(
+                v.get("spec")
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing 'spec'"))?,
+            )?;
+            Ok(IpcCommand::AddPane(spec))
+        }
+        "remove_pane" => {
+            let id = v
+                .get("id")
+                .and_then(|i| i.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing 'id'"))? as u32;
+            Ok(IpcCommand::RemovePane(id))
+        }
+        "focus_pane" => {
+            let id = v
+                .get("id")
+                .and_then(|i| i.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing 'id'"))? as u32;
+            Ok(IpcCommand::FocusPane(id))
+        }
+        "split" => {
+            let direction = v
+                .get("direction")
+                .and_then(|d| d.as_str())
+                .unwrap_or("vertical")
+                .to_string();
+            let spec: PaneSpec = serde_json::from_value(
+                v.get("spec")
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing 'spec'"))?,
+            )?;
+            Ok(IpcCommand::Split { direction, spec })
+        }
+        "maximize" => {
+            let id = v
+                .get("id")
+                .and_then(|i| i.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing 'id'"))? as u32;
+            Ok(IpcCommand::Maximize(id))
+        }
+        "send_keys" => {
+            let id = v
+                .get("id")
+                .and_then(|i| i.as_u64())
+                .ok_or_else(|| anyhow::anyhow!("missing 'id'"))? as u32;
+            let keys = v
+                .get("keys")
+                .and_then(|k| k.as_str())
+                .ok_or_else(|| anyhow::anyhow!("missing 'keys'"))?
+                .to_string();
+            Ok(IpcCommand::SendKeys { id, keys })
+        }
+        "quit" => Ok(IpcCommand::Quit),
+        _ => Err(anyhow::anyhow!("unknown command: {}", cmd_type)),
+    }
+}
+
+/// Connect to a running tmuch instance and send a command.
+pub fn send_command(json: &str) -> Result<String> {
+    use std::os::unix::net::UnixStream;
+
+    // Find the first tmuch socket
+    let socket_path = find_socket()?;
+
+    let mut stream =
+        UnixStream::connect(&socket_path).map_err(|e| anyhow::anyhow!("connect: {}", e))?;
+    stream.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
+
+    writeln!(stream, "{}", json)?;
+    stream.flush()?;
+
+    let reader = BufReader::new(&stream);
+    for line in reader.lines() {
+        let line = line?;
+        if !line.is_empty() {
+            return Ok(line);
+        }
+    }
+
+    Err(anyhow::anyhow!("no response from tmuch"))
+}
+
+fn find_socket() -> Result<PathBuf> {
+    for entry in std::fs::read_dir("/tmp")? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with("tmuch-") && name.ends_with(".sock") {
+            return Ok(entry.path());
+        }
+    }
+    Err(anyhow::anyhow!(
+        "no running tmuch instance found (no /tmp/tmuch-*.sock)"
+    ))
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,6 +2,17 @@ use ratatui::layout::Rect;
 
 pub type PaneId = u32;
 
+/// Reference to a split node found during hit-testing.
+#[derive(Debug, Clone)]
+pub struct SplitRef {
+    /// Path from the root to the split node (0 = first child, 1 = second child).
+    pub path: Vec<usize>,
+    /// Direction of the split.
+    pub direction: SplitDirection,
+    /// Area of the parent split node.
+    pub area: Rect,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SplitDirection {
     Horizontal,
@@ -146,6 +157,103 @@ impl LayoutNode {
             }
             LayoutNode::Split { first, second, .. } => {
                 first.split_leaf(target, new_id, dir) || second.split_leaf(target, new_id, dir)
+            }
+        }
+    }
+
+    /// Find the split whose boundary is near (x, y), within tolerance cells.
+    /// Returns a SplitRef if found.
+    pub fn find_split_at(&self, x: u16, y: u16, area: Rect, tolerance: u16) -> Option<SplitRef> {
+        self.find_split_at_inner(x, y, area, tolerance, &mut Vec::new())
+    }
+
+    fn find_split_at_inner(
+        &self,
+        x: u16,
+        y: u16,
+        area: Rect,
+        tolerance: u16,
+        path: &mut Vec<usize>,
+    ) -> Option<SplitRef> {
+        match self {
+            LayoutNode::Leaf(_) => None,
+            LayoutNode::Split {
+                direction,
+                ratio,
+                first,
+                second,
+            } => {
+                let (a, b) = split_rect(area, *direction, *ratio);
+
+                // Check if the position is near the boundary
+                let near_boundary = match direction {
+                    SplitDirection::Vertical => {
+                        // Boundary is at a.x + a.width (= b.x)
+                        let boundary_x = a.x + a.width;
+                        x >= boundary_x.saturating_sub(tolerance)
+                            && x <= boundary_x + tolerance
+                            && y >= area.y
+                            && y < area.y + area.height
+                    }
+                    SplitDirection::Horizontal => {
+                        // Boundary is at a.y + a.height (= b.y)
+                        let boundary_y = a.y + a.height;
+                        y >= boundary_y.saturating_sub(tolerance)
+                            && y <= boundary_y + tolerance
+                            && x >= area.x
+                            && x < area.x + area.width
+                    }
+                };
+
+                if near_boundary {
+                    return Some(SplitRef {
+                        path: path.clone(),
+                        direction: *direction,
+                        area,
+                    });
+                }
+
+                // Recurse into children
+                path.push(0);
+                if let Some(result) = first.find_split_at_inner(x, y, a, tolerance, path) {
+                    return Some(result);
+                }
+                path.pop();
+
+                path.push(1);
+                if let Some(result) = second.find_split_at_inner(x, y, b, tolerance, path) {
+                    return Some(result);
+                }
+                path.pop();
+
+                None
+            }
+        }
+    }
+
+    /// Update a split's ratio at the given path.
+    pub fn set_ratio_at(&mut self, path: &[usize], ratio: f32) {
+        if path.is_empty() {
+            // Apply ratio to this node
+            if let LayoutNode::Split {
+                ratio: ref mut r, ..
+            } = self
+            {
+                *r = ratio;
+            }
+            return;
+        }
+
+        if let LayoutNode::Split {
+            ref mut first,
+            ref mut second,
+            ..
+        } = self
+        {
+            match path[0] {
+                0 => first.set_ratio_at(&path[1..], ratio),
+                1 => second.set_ratio_at(&path[1..], ratio),
+                _ => {}
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod azlin_integration;
 mod config;
 mod consts;
+mod ipc;
 mod keys;
 mod layout;
 mod layouts;
@@ -66,6 +67,12 @@ enum Commands {
         #[arg(short, long)]
         resource_group: Option<String>,
     },
+
+    /// Send a command to a running tmuch instance
+    Ctl {
+        /// JSON command to send (e.g. '{"command":"list_panes"}')
+        json: String,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -92,6 +99,18 @@ fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Azlin { resource_group }) => {
             return app::run_azlin(resource_group.clone());
+        }
+        Some(Commands::Ctl { json }) => {
+            match ipc::send_command(json) {
+                Ok(response) => {
+                    println!("{}", response);
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            }
+            return Ok(());
         }
         None => {}
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -293,6 +293,18 @@ impl PaneManager {
         }
     }
 
+    /// Get a reference to the layout tree (for split detection).
+    pub fn layout(&self) -> Option<&LayoutNode> {
+        self.layout.as_ref()
+    }
+
+    /// Update a split's ratio at the given path.
+    pub fn set_ratio_at(&mut self, path: &[usize], ratio: f32) {
+        if let Some(ref mut layout) = self.layout {
+            layout.set_ratio_at(path, ratio);
+        }
+    }
+
     /// Rebuild the auto-grid layout from current pane IDs.
     fn rebuild_auto_grid(&mut self) {
         let ids = {

--- a/src/source/clock.rs
+++ b/src/source/clock.rs
@@ -1,0 +1,75 @@
+use super::{ContentSource, PaneSpec};
+use anyhow::Result;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Text;
+use ratatui::widgets::{Paragraph, Widget};
+
+/// A clock widget pane that renders the current time using custom widget rendering.
+pub struct ClockSource;
+
+impl ContentSource for ClockSource {
+    fn capture(&mut self, _width: u16, _height: u16) -> Result<String> {
+        // Fallback text capture for non-widget paths
+        let now = chrono::Local::now().format("%H:%M:%S").to_string();
+        Ok(now)
+    }
+
+    fn send_keys(&mut self, _keys: &str) -> Result<()> {
+        Ok(()) // not interactive
+    }
+
+    fn name(&self) -> &str {
+        "clock"
+    }
+
+    fn source_label(&self) -> &str {
+        "widget"
+    }
+
+    fn is_interactive(&self) -> bool {
+        false
+    }
+
+    fn to_spec(&self) -> PaneSpec {
+        PaneSpec::Plugin {
+            plugin_name: "clock".to_string(),
+            config: toml::Value::Table(toml::map::Map::new()),
+        }
+    }
+
+    fn has_custom_render(&self) -> bool {
+        true
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let now = chrono::Local::now().format("%H:%M:%S").to_string();
+        let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+
+        // Center vertically: put the time in the middle row
+        let mid_y = area.height / 2;
+
+        if area.height >= 3 && mid_y >= 1 {
+            // Date line above time
+            let date_text = Text::from(date);
+            let date_para = Paragraph::new(date_text)
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::DarkGray));
+            let date_area = Rect::new(area.x, area.y + mid_y - 1, area.width, 1);
+            Widget::render(date_para, date_area, buf);
+        }
+
+        // Time line
+        let time_text = Text::from(now);
+        let time_para = Paragraph::new(time_text)
+            .alignment(Alignment::Center)
+            .style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            );
+        let time_area = Rect::new(area.x, area.y + mid_y, area.width, 1);
+        Widget::render(time_para, time_area, buf);
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -1,10 +1,14 @@
+pub mod clock;
 pub mod command;
 pub mod http;
 pub mod local_tmux;
+pub mod registry;
 pub mod ssh_subprocess;
 pub mod tail;
 
 use anyhow::Result;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
 
 /// A content source that can provide terminal output for a pane.
 pub trait ContentSource: Send {
@@ -28,6 +32,15 @@ pub trait ContentSource: Send {
 
     /// Serialize back to a layout spec for saving.
     fn to_spec(&self) -> PaneSpec;
+
+    /// Whether this source renders custom widgets (instead of text capture).
+    fn has_custom_render(&self) -> bool {
+        false
+    }
+
+    /// Render custom widgets directly into the buffer.
+    /// Only called if has_custom_render() returns true.
+    fn render(&self, _area: Rect, _buf: &mut Buffer) {}
 }
 
 /// Specification for recreating a pane from a layout file.
@@ -59,6 +72,12 @@ pub enum PaneSpec {
         #[serde(default = "default_http_interval")]
         interval_ms: u64,
     },
+    #[serde(rename = "plugin")]
+    Plugin {
+        plugin_name: String,
+        #[serde(default = "default_plugin_config")]
+        config: toml::Value,
+    },
 }
 
 fn default_http_interval() -> u64 {
@@ -69,9 +88,16 @@ fn default_interval() -> u64 {
     5000
 }
 
+fn default_plugin_config() -> toml::Value {
+    toml::Value::Table(toml::map::Map::new())
+}
+
 /// Parse a `-n` argument into a content source.
-/// Supports prefixes: `watch:cmd:interval`, `tail:path`, or plain tmux command.
+/// Supports prefixes: `watch:cmd:interval`, `tail:path`, `clock:`, or plain tmux command.
 pub fn parse_new_arg(arg: &str) -> NewPaneRequest {
+    if arg == "clock:" || arg == "clock" {
+        return NewPaneRequest::Clock;
+    }
     if let Some(rest) = arg.strip_prefix("tail:") {
         NewPaneRequest::Tail {
             path: rest.to_string(),
@@ -119,4 +145,5 @@ pub enum NewPaneRequest {
     Command { command: String, interval_ms: u64 },
     Tail { path: String },
     Http { url: String, interval_ms: u64 },
+    Clock,
 }

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use super::ContentSource;
+
+type PluginConstructor = Box<dyn Fn(toml::Value) -> Box<dyn ContentSource> + Send + Sync>;
+
+/// A registry that maps plugin names to constructors for creating content sources.
+pub struct PluginRegistry {
+    plugins: HashMap<String, PluginConstructor>,
+}
+
+impl PluginRegistry {
+    pub fn new() -> Self {
+        let mut reg = Self {
+            plugins: HashMap::new(),
+        };
+        // Register built-in plugins
+        reg.register(
+            "clock",
+            Box::new(|_config| Box::new(super::clock::ClockSource)),
+        );
+        reg
+    }
+
+    pub fn register(&mut self, name: &str, constructor: PluginConstructor) {
+        self.plugins.insert(name.to_string(), constructor);
+    }
+
+    pub fn create(&self, name: &str, config: toml::Value) -> Option<Box<dyn ContentSource>> {
+        self.plugins.get(name).map(|ctor| ctor(config))
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -96,12 +96,16 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
         let inner = block.inner(*rect);
 
-        // Parse ANSI content
-        let text = pane.content.as_bytes().into_text().unwrap_or_default();
-
-        let paragraph = Paragraph::new(text).block(block);
-        frame.render_widget(paragraph, *rect);
-        let _ = inner; // inner used implicitly by block
+        if pane.source.has_custom_render() {
+            // Custom widget rendering path
+            frame.render_widget(block, *rect);
+            pane.source.render(inner, frame.buffer_mut());
+        } else {
+            // Standard text rendering path: parse ANSI content
+            let text = pane.content.as_bytes().into_text().unwrap_or_default();
+            let paragraph = Paragraph::new(text).block(block);
+            frame.render_widget(paragraph, *rect);
+        }
     }
 
     // Draw status bar


### PR DESCRIPTION
## Summary
- **Phase 4 — Widget rendering**: `ContentSource` trait gains `has_custom_render()` / `render()` for direct ratatui widget output. Added `ClockSource` (proof of concept), `PluginRegistry` for named plugin constructors, `Plugin` variant in `PaneSpec`, and `tmuch -n clock:` CLI support.
- **Phase 5 — IPC via Unix socket**: Background thread listens on `/tmp/tmuch-{pid}.sock` for newline-delimited JSON commands (`list_panes`, `add_pane`, `remove_pane`, `focus_pane`, `split`, `maximize`, `send_keys`, `quit`). New `tmuch ctl '{"command":"list_panes"}'` subcommand to control a running instance.
- **Phase 6 — Border drag resize**: Mouse-down near split boundaries enters drag mode, mouse-drag updates split ratios in real time, mouse-up stops. Added `find_split_at()` and `set_ratio_at()` to `LayoutNode`.

## Test plan
- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 27 unit tests pass
- [x] `cargo build --release` — succeeds
- [x] `bash tests/run-e2e.sh` — all 43 E2E tests pass
- [ ] Manual: `tmuch -n clock:` shows a live clock widget with centered time
- [ ] Manual: start tmuch, then `tmuch ctl '{"command":"list_panes"}'` lists panes
- [ ] Manual: drag a split boundary to resize panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)