### PR TITLE
Add app discovery: tmuch apps + Ctrl-N launcher

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,44 @@ use std::io;
 use std::sync::mpsc;
 use std::time::Duration;
 
+/// State for the app launcher overlay.
+pub struct AppLauncherState {
+    pub apps: Vec<(&'static str, &'static str, &'static str)>, // (name, desc, usage)
+    pub selected: usize,
+}
+
+impl AppLauncherState {
+    pub fn new() -> Self {
+        let registry = crate::source::registry::PluginRegistry::new();
+        let apps: Vec<_> = registry
+            .list()
+            .iter()
+            .map(|info| (info.name, info.description, info.usage))
+            .collect();
+        Self { apps, selected: 0 }
+    }
+
+    pub fn select_next(&mut self) {
+        if !self.apps.is_empty() {
+            self.selected = (self.selected + 1) % self.apps.len();
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        if !self.apps.is_empty() {
+            self.selected = if self.selected == 0 {
+                self.apps.len() - 1
+            } else {
+                self.selected - 1
+            };
+        }
+    }
+
+    pub fn selected_usage(&self) -> Option<&'static str> {
+        self.apps.get(self.selected).map(|(_, _, u)| *u)
+    }
+}
+
 /// State for the command editor overlay.
 pub struct CommandEditorState {
     pub entries: Vec<(char, String)>,
@@ -100,6 +138,7 @@ pub struct App {
     pub theme: Theme,
     pub plugin_registry: PluginRegistry,
     pub drag_state: Option<DragState>,
+    pub app_launcher: Option<AppLauncherState>,
 }
 
 impl App {
@@ -114,6 +153,7 @@ impl App {
             command_editor: None,
             pane_rects: Vec::new(),
             theme,
+            app_launcher: None,
             plugin_registry: PluginRegistry::new(),
             drag_state: None,
         }
@@ -405,6 +445,84 @@ impl App {
             }
             Action::SwapPane => {
                 self.pane_manager.swap_focused_with_next();
+            }
+            Action::OpenAppLauncher => {
+                self.app_launcher = Some(AppLauncherState::new());
+                self.mode = Mode::AppLauncher;
+            }
+            Action::LauncherUp => {
+                if let Some(ref mut launcher) = self.app_launcher {
+                    launcher.select_prev();
+                }
+            }
+            Action::LauncherDown => {
+                if let Some(ref mut launcher) = self.app_launcher {
+                    launcher.select_next();
+                }
+            }
+            Action::LauncherConfirm => {
+                if let Some(ref launcher) = self.app_launcher {
+                    if let Some(usage) = launcher.selected_usage() {
+                        // Parse the usage string as a -n argument
+                        let arg = usage.split_once(' ').map(|(u, _)| u).unwrap_or(usage);
+                        let request = crate::source::parse_new_arg(arg);
+                        match request {
+                            NewPaneRequest::TmuxCommand { command } => {
+                                let _ = self.create_local_tmux(Some(&command));
+                            }
+                            NewPaneRequest::Command {
+                                command,
+                                interval_ms,
+                            } => {
+                                let source = CommandSource::new(command, interval_ms);
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::Tail { path } => {
+                                if let Ok(source) = TailSource::new(&path) {
+                                    self.pane_manager.add(Box::new(source));
+                                }
+                            }
+                            NewPaneRequest::Http { url, interval_ms } => {
+                                let source = HttpSource::new(url, interval_ms);
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::Clock => {
+                                let source = crate::source::clock::ClockSource;
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::Weather { city, interval_ms } => {
+                                let source =
+                                    crate::source::weather::WeatherSource::new(city, interval_ms);
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::SysInfo { interval_ms } => {
+                                let source =
+                                    crate::source::sysinfo::SysInfoSource::new(interval_ms);
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::Snake => {
+                                let source = crate::source::snake::SnakeSource::new();
+                                self.pane_manager.add(Box::new(source));
+                            }
+                            NewPaneRequest::Sparkline {
+                                command,
+                                interval_ms,
+                            } => {
+                                let source = crate::source::sparkline_monitor::SparklineSource::new(
+                                    command,
+                                    interval_ms,
+                                );
+                                self.pane_manager.add(Box::new(source));
+                            }
+                        }
+                    }
+                }
+                self.app_launcher = None;
+                self.mode = Mode::Normal;
+            }
+            Action::LauncherCancel => {
+                self.app_launcher = None;
+                self.mode = Mode::Normal;
             }
         }
         Ok(())

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,6 +8,7 @@ pub enum Mode {
     PaneFocused,
     SessionPicker,
     CommandEditor,
+    AppLauncher,
 }
 
 #[derive(Debug)]
@@ -40,6 +41,11 @@ pub enum Action {
     SplitHorizontal,
     ToggleMaximize,
     SwapPane,
+    OpenAppLauncher,
+    LauncherUp,
+    LauncherDown,
+    LauncherConfirm,
+    LauncherCancel,
 }
 
 pub fn handle(event: KeyEvent, mode: &Mode, config: &Config) -> Option<Action> {
@@ -48,6 +54,7 @@ pub fn handle(event: KeyEvent, mode: &Mode, config: &Config) -> Option<Action> {
         Mode::PaneFocused => handle_pane_focused(event),
         Mode::SessionPicker => handle_picker(event),
         Mode::CommandEditor => handle_command_editor(event),
+        Mode::AppLauncher => handle_app_launcher(event),
     }
 }
 
@@ -65,6 +72,7 @@ fn handle_normal(event: KeyEvent, config: &Config) -> Option<Action> {
             KeyCode::Char('h') => Some(Action::SplitHorizontal),
             KeyCode::Char('f') => Some(Action::ToggleMaximize),
             KeyCode::Char('x') => Some(Action::SwapPane),
+            KeyCode::Char('n') => Some(Action::OpenAppLauncher),
             _ => None,
         };
     }
@@ -119,6 +127,16 @@ fn handle_command_editor(event: KeyEvent) -> Option<Action> {
         KeyCode::Down | KeyCode::Char('j') => Some(Action::EditorDown),
         KeyCode::Char('d') => Some(Action::EditorDelete),
         KeyCode::Char('a') => None, // no-op: hint says edit config file
+        _ => None,
+    }
+}
+
+fn handle_app_launcher(event: KeyEvent) -> Option<Action> {
+    match event.code {
+        KeyCode::Esc => Some(Action::LauncherCancel),
+        KeyCode::Up | KeyCode::Char('k') => Some(Action::LauncherUp),
+        KeyCode::Down | KeyCode::Char('j') => Some(Action::LauncherDown),
+        KeyCode::Enter => Some(Action::LauncherConfirm),
         _ => None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,9 @@ enum Commands {
         /// JSON command to send (e.g. '{"command":"list_panes"}')
         json: String,
     },
+
+    /// List available pane types and widget apps
+    Apps,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -110,6 +113,17 @@ fn main() -> anyhow::Result<()> {
                     std::process::exit(1);
                 }
             }
+            return Ok(());
+        }
+        Some(Commands::Apps) => {
+            let registry = source::registry::PluginRegistry::new();
+            println!("Available pane types:\n");
+            for info in registry.list() {
+                println!("  {:<12} {}", info.name, info.description);
+                println!("  {:<12} Usage: {}", "", info.usage);
+                println!();
+            }
+            println!("\nExample: tmuch -n 'weather:Seattle' -n 'sysinfo:' -n 'snake:'");
             return Ok(());
         }
         None => {}

--- a/src/source/registry.rs
+++ b/src/source/registry.rs
@@ -1,26 +1,36 @@
-use std::collections::HashMap;
-
 use super::ContentSource;
 
 type PluginConstructor = Box<dyn Fn(toml::Value) -> Box<dyn ContentSource> + Send + Sync>;
 
-/// A registry that maps plugin names to constructors for creating content sources.
+/// Metadata for a registered plugin/app.
+pub struct PluginInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub usage: &'static str,
+    constructor: PluginConstructor,
+}
+
+/// A registry that maps plugin names to constructors and metadata.
 pub struct PluginRegistry {
-    plugins: HashMap<String, PluginConstructor>,
+    plugins: Vec<PluginInfo>,
 }
 
 impl PluginRegistry {
     pub fn new() -> Self {
         let mut reg = Self {
-            plugins: HashMap::new(),
+            plugins: Vec::new(),
         };
-        // Register built-in plugins
-        reg.register(
+
+        reg.add(
             "clock",
-            Box::new(|_config| Box::new(super::clock::ClockSource)),
+            "Live clock display",
+            "clock:",
+            Box::new(|_| Box::new(super::clock::ClockSource)),
         );
-        reg.register(
+        reg.add(
             "weather",
+            "Weather from wttr.in with color-coded temperature",
+            "weather:City or weather:City:interval_ms",
             Box::new(|config| {
                 let city = config
                     .get("city")
@@ -34,8 +44,10 @@ impl PluginRegistry {
                 Box::new(super::weather::WeatherSource::new(city, interval_ms))
             }),
         );
-        reg.register(
+        reg.add(
             "sysinfo",
+            "CPU, memory, disk gauges with load average",
+            "sysinfo: or sysinfo:interval_ms",
             Box::new(|config| {
                 let interval_ms = config
                     .get("interval_ms")
@@ -44,12 +56,16 @@ impl PluginRegistry {
                 Box::new(super::sysinfo::SysInfoSource::new(interval_ms))
             }),
         );
-        reg.register(
+        reg.add(
             "snake",
-            Box::new(|_config| Box::new(super::snake::SnakeSource::new())),
+            "Playable snake game (arrow keys to steer)",
+            "snake:",
+            Box::new(|_| Box::new(super::snake::SnakeSource::new())),
         );
-        reg.register(
+        reg.add(
             "sparkline",
+            "Real-time sparkline chart from command output",
+            "spark:command:interval_ms",
             Box::new(|config| {
                 let command = config
                     .get("command")
@@ -66,14 +82,53 @@ impl PluginRegistry {
                 ))
             }),
         );
+
+        // Built-in non-widget sources (for documentation only)
+        reg.add(
+            "watch",
+            "Run a command periodically and display output",
+            "watch:command:interval_ms",
+            Box::new(|_| Box::new(super::clock::ClockSource)), // placeholder
+        );
+        reg.add(
+            "tail",
+            "Follow a file with tail -f",
+            "tail:/path/to/file",
+            Box::new(|_| Box::new(super::clock::ClockSource)),
+        );
+        reg.add(
+            "http",
+            "Poll an HTTP URL periodically",
+            "http:url:interval_ms",
+            Box::new(|_| Box::new(super::clock::ClockSource)),
+        );
+
         reg
     }
 
-    pub fn register(&mut self, name: &str, constructor: PluginConstructor) {
-        self.plugins.insert(name.to_string(), constructor);
+    fn add(
+        &mut self,
+        name: &'static str,
+        description: &'static str,
+        usage: &'static str,
+        constructor: PluginConstructor,
+    ) {
+        self.plugins.push(PluginInfo {
+            name,
+            description,
+            usage,
+            constructor,
+        });
     }
 
     pub fn create(&self, name: &str, config: toml::Value) -> Option<Box<dyn ContentSource>> {
-        self.plugins.get(name).map(|ctor| ctor(config))
+        self.plugins
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| (p.constructor)(config))
+    }
+
+    pub fn list(&self) -> &[PluginInfo] {
+        &self.plugins
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -120,6 +120,11 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.mode == Mode::CommandEditor {
         draw_command_editor(frame, app, main_area);
     }
+
+    // Draw app launcher overlay if active
+    if app.mode == Mode::AppLauncher {
+        draw_app_launcher(frame, app, main_area);
+    }
 }
 
 fn sep() -> Span<'static> {
@@ -160,6 +165,8 @@ fn draw_hints_bar(frame: &mut Frame, app: &App, area: Rect) {
             spans.push(sep());
             spans.extend(hint("F11", " Max", Color::Yellow));
             spans.push(sep());
+            spans.extend(hint("^N", " Apps", Color::LightCyan));
+            spans.push(sep());
             spans.extend(hint("1-9", " Bindings", Color::Magenta));
         }
         Mode::PaneFocused => {
@@ -193,6 +200,13 @@ fn draw_hints_bar(frame: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::Rgb(80, 80, 80)),
             ));
         }
+        Mode::AppLauncher => {
+            spans.extend(hint("\u{2191}\u{2193}/jk", " Nav", Color::Yellow));
+            spans.push(sep());
+            spans.extend(hint("Enter", " Launch", Color::Green));
+            spans.push(sep());
+            spans.extend(hint("Esc", " Cancel", Color::Red));
+        }
     }
 
     let line = Line::from(spans);
@@ -206,6 +220,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Mode::PaneFocused => "FOCUSED",
         Mode::SessionPicker => "PICKER",
         Mode::CommandEditor => "EDITOR",
+        Mode::AppLauncher => "APPS",
     };
 
     let theme = &app.theme;
@@ -367,6 +382,66 @@ fn draw_command_editor(frame: &mut Frame, app: &App, area: Rect) {
             .borders(Borders::ALL)
             .border_type(border_type)
             .border_style(Style::default().fg(Color::Cyan)),
+    );
+
+    frame.render_widget(list, popup);
+}
+
+fn draw_app_launcher(frame: &mut Frame, app: &App, area: Rect) {
+    let launcher = match &app.app_launcher {
+        Some(l) => l,
+        None => return,
+    };
+
+    let border_type = parse_border_type(&app.theme.border.style);
+    let w = 60.min(area.width.saturating_sub(4));
+    let h = ((launcher.apps.len() as u16) + 3)
+        .min(area.height.saturating_sub(4))
+        .max(6);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    let popup = Rect::new(x, y, w, h);
+
+    frame.render_widget(Clear, popup);
+
+    let items: Vec<ListItem> = launcher
+        .apps
+        .iter()
+        .enumerate()
+        .map(|(i, (name, desc, _usage))| {
+            let prefix = if i == launcher.selected {
+                "\u{25b6} "
+            } else {
+                "  "
+            };
+            let style = if i == launcher.selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let line = Line::from(vec![
+                Span::styled(prefix, style),
+                Span::styled(*name, style),
+                Span::styled(
+                    format!("  {}", desc),
+                    Style::default().fg(Color::Rgb(100, 100, 100)),
+                ),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .title(Line::from(Span::styled(
+                " Apps ",
+                Style::default().fg(Color::LightCyan),
+            )))
+            .borders(Borders::ALL)
+            .border_type(border_type)
+            .border_style(Style::default().fg(Color::LightCyan)),
     );
 
     frame.render_widget(list, popup);


### PR DESCRIPTION
Three discovery paths for available pane types:

1. **CLI**: `tmuch apps` lists all registered apps with name, description, usage
2. **TUI**: `Ctrl-N` opens app launcher overlay — browse with arrows, launch with Enter
3. **Hints bar**: Shows `^N Apps` in cyan in Normal mode

Registry enhanced with metadata (description, usage) per plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)