### PR TITLE
Add/edit/delete command bindings in settings editor

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -69,10 +69,21 @@ impl AppLauncherState {
     }
 }
 
+/// Input mode for the command editor overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditorInputMode {
+    Browse,
+    InputKey,
+    InputCommand,
+}
+
 /// State for the command editor overlay.
 pub struct CommandEditorState {
     pub entries: Vec<(char, String)>,
     pub selected: usize,
+    pub input_mode: EditorInputMode,
+    pub input_buffer: String,
+    pub pending_key: Option<char>,
 }
 
 impl CommandEditorState {
@@ -86,6 +97,9 @@ impl CommandEditorState {
         Self {
             entries,
             selected: 0,
+            input_mode: EditorInputMode::Browse,
+            input_buffer: String::new(),
+            pending_key: None,
         }
     }
 
@@ -157,6 +171,13 @@ impl App {
             plugin_registry: PluginRegistry::new(),
             drag_state: None,
         }
+    }
+
+    pub fn editor_input_mode(&self) -> EditorInputMode {
+        self.command_editor
+            .as_ref()
+            .map(|e| e.input_mode.clone())
+            .unwrap_or(EditorInputMode::Browse)
     }
 
     pub fn add_local_tmux(&mut self, name: &str, _owned: bool) {
@@ -416,7 +437,70 @@ impl App {
                 if let Some(ref mut editor) = self.command_editor {
                     if let Some(key) = editor.delete_selected() {
                         self.config.bindings.remove(&key);
+                        let _ = crate::config::save_bindings(&self.config.bindings);
                     }
+                }
+            }
+            Action::EditorAdd => {
+                if let Some(ref mut editor) = self.command_editor {
+                    editor.input_mode = EditorInputMode::InputKey;
+                    editor.input_buffer.clear();
+                    editor.pending_key = None;
+                }
+            }
+            Action::EditorEdit => {
+                if let Some(ref mut editor) = self.command_editor {
+                    if let Some((key, cmd)) = editor.entries.get(editor.selected).cloned() {
+                        editor.pending_key = Some(key);
+                        editor.input_buffer = cmd;
+                        editor.input_mode = EditorInputMode::InputCommand;
+                    }
+                }
+            }
+            Action::EditorSetKey(c) => {
+                if let Some(ref mut editor) = self.command_editor {
+                    editor.pending_key = Some(c);
+                    editor.input_buffer.clear();
+                    editor.input_mode = EditorInputMode::InputCommand;
+                }
+            }
+            Action::EditorTypeChar(c) => {
+                if let Some(ref mut editor) = self.command_editor {
+                    editor.input_buffer.push(c);
+                }
+            }
+            Action::EditorBackspace => {
+                if let Some(ref mut editor) = self.command_editor {
+                    editor.input_buffer.pop();
+                }
+            }
+            Action::EditorConfirm => {
+                if let Some(ref mut editor) = self.command_editor {
+                    if let Some(key) = editor.pending_key {
+                        let cmd = editor.input_buffer.clone();
+                        if !cmd.is_empty() {
+                            self.config.bindings.insert(key, cmd.clone());
+                            // Update entries list
+                            if let Some(entry) = editor.entries.iter_mut().find(|(k, _)| *k == key)
+                            {
+                                entry.1 = cmd;
+                            } else {
+                                editor.entries.push((key, cmd));
+                                editor.entries.sort_by_key(|(k, _)| *k);
+                            }
+                            let _ = crate::config::save_bindings(&self.config.bindings);
+                        }
+                    }
+                    editor.input_mode = EditorInputMode::Browse;
+                    editor.input_buffer.clear();
+                    editor.pending_key = None;
+                }
+            }
+            Action::EditorCancelInput => {
+                if let Some(ref mut editor) = self.command_editor {
+                    editor.input_mode = EditorInputMode::Browse;
+                    editor.input_buffer.clear();
+                    editor.pending_key = None;
                 }
             }
             Action::EditorClose => {
@@ -786,7 +870,9 @@ pub fn run_azlin(resource_group: Option<String>) -> Result<()> {
             let main_area = Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2));
             match event::read()? {
                 Event::Key(key) => {
-                    if let Some(action) = keys::handle(key, &app.mode, &app.config) {
+                    if let Some(action) =
+                        keys::handle(key, &app.mode, &app.config, &app.editor_input_mode())
+                    {
                         app.handle_action(action)?;
                     }
                 }
@@ -967,7 +1053,9 @@ pub fn run(
             let main_area = Rect::new(0, 1, term_size.width, term_size.height.saturating_sub(2));
             match event::read()? {
                 Event::Key(key) => {
-                    if let Some(action) = keys::handle(key, &app.mode, &app.config) {
+                    if let Some(action) =
+                        keys::handle(key, &app.mode, &app.config, &app.editor_input_mode())
+                    {
                         app.handle_action(action)?;
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,46 @@ fn config_path() -> PathBuf {
         .join("config.toml")
 }
 
+/// Save the bindings section back to the config file.
+/// Reads the existing config, updates the [bindings] table, and writes it back.
+pub fn save_bindings(bindings: &HashMap<char, String>) -> Result<()> {
+    let path = config_path();
+
+    // Read existing config or start fresh
+    let existing = if path.exists() {
+        std::fs::read_to_string(&path)?
+    } else {
+        String::new()
+    };
+
+    // Parse as a TOML value so we preserve other sections
+    let mut doc: toml::Value = if existing.is_empty() {
+        toml::Value::Table(toml::map::Map::new())
+    } else {
+        toml::from_str(&existing)?
+    };
+
+    // Build the new bindings table
+    let mut bindings_table = toml::map::Map::new();
+    for (k, v) in bindings {
+        bindings_table.insert(k.to_string(), toml::Value::String(v.clone()));
+    }
+
+    // Update the document
+    if let toml::Value::Table(ref mut table) = doc {
+        table.insert("bindings".to_string(), toml::Value::Table(bindings_table));
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let output = toml::to_string_pretty(&doc)?;
+    std::fs::write(&path, output)?;
+    Ok(())
+}
+
 pub fn load() -> Result<Config> {
     let path = config_path();
     let mut config = if path.exists() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,3 +1,4 @@
+use crate::app::EditorInputMode;
 use crate::config::Config;
 use crate::layout::PaneId;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -35,6 +36,13 @@ pub enum Action {
     EditorDown,
     EditorDelete,
     EditorClose,
+    EditorAdd,
+    EditorEdit,
+    EditorSetKey(char),
+    EditorTypeChar(char),
+    EditorBackspace,
+    EditorConfirm,
+    EditorCancelInput,
     #[allow(dead_code)]
     FocusPane(PaneId),
     SplitVertical,
@@ -48,12 +56,17 @@ pub enum Action {
     LauncherCancel,
 }
 
-pub fn handle(event: KeyEvent, mode: &Mode, config: &Config) -> Option<Action> {
+pub fn handle(
+    event: KeyEvent,
+    mode: &Mode,
+    config: &Config,
+    editor_input_mode: &EditorInputMode,
+) -> Option<Action> {
     match mode {
         Mode::Normal => handle_normal(event, config),
         Mode::PaneFocused => handle_pane_focused(event),
         Mode::SessionPicker => handle_picker(event),
-        Mode::CommandEditor => handle_command_editor(event),
+        Mode::CommandEditor => handle_command_editor(event, editor_input_mode),
         Mode::AppLauncher => handle_app_launcher(event),
     }
 }
@@ -120,14 +133,29 @@ fn handle_picker(event: KeyEvent) -> Option<Action> {
     }
 }
 
-fn handle_command_editor(event: KeyEvent) -> Option<Action> {
-    match event.code {
-        KeyCode::Esc => Some(Action::EditorClose),
-        KeyCode::Up | KeyCode::Char('k') => Some(Action::EditorUp),
-        KeyCode::Down | KeyCode::Char('j') => Some(Action::EditorDown),
-        KeyCode::Char('d') => Some(Action::EditorDelete),
-        KeyCode::Char('a') => None, // no-op: hint says edit config file
-        _ => None,
+fn handle_command_editor(event: KeyEvent, input_mode: &EditorInputMode) -> Option<Action> {
+    match input_mode {
+        EditorInputMode::Browse => match event.code {
+            KeyCode::Esc => Some(Action::EditorClose),
+            KeyCode::Up | KeyCode::Char('k') => Some(Action::EditorUp),
+            KeyCode::Down | KeyCode::Char('j') => Some(Action::EditorDown),
+            KeyCode::Char('d') => Some(Action::EditorDelete),
+            KeyCode::Char('a') => Some(Action::EditorAdd),
+            KeyCode::Char('e') | KeyCode::Enter => Some(Action::EditorEdit),
+            _ => None,
+        },
+        EditorInputMode::InputKey => match event.code {
+            KeyCode::Esc => Some(Action::EditorCancelInput),
+            KeyCode::Char(c) if c.is_ascii_digit() => Some(Action::EditorSetKey(c)),
+            _ => None,
+        },
+        EditorInputMode::InputCommand => match event.code {
+            KeyCode::Esc => Some(Action::EditorCancelInput),
+            KeyCode::Enter => Some(Action::EditorConfirm),
+            KeyCode::Backspace => Some(Action::EditorBackspace),
+            KeyCode::Char(c) => Some(Action::EditorTypeChar(c)),
+            _ => None,
+        },
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -189,16 +189,36 @@ fn draw_hints_bar(frame: &mut Frame, app: &App, area: Rect) {
             spans.extend(hint("Esc", " Cancel", Color::Red));
         }
         Mode::CommandEditor => {
-            spans.extend(hint("\u{2191}\u{2193}", " Nav", Color::Yellow));
-            spans.push(sep());
-            spans.extend(hint("d", " Delete", Color::Red));
-            spans.push(sep());
-            spans.extend(hint("Esc", " Close", Color::Red));
-            spans.push(sep());
-            spans.push(Span::styled(
-                "Edit ~/.config/tmuch/config.toml to add",
-                Style::default().fg(Color::Rgb(80, 80, 80)),
-            ));
+            use crate::app::EditorInputMode;
+            let input_mode = app.editor_input_mode();
+            match input_mode {
+                EditorInputMode::Browse => {
+                    spans.extend(hint("\u{2191}\u{2193}", " Nav", Color::Yellow));
+                    spans.push(sep());
+                    spans.extend(hint("a", " Add", Color::Green));
+                    spans.push(sep());
+                    spans.extend(hint("e/Enter", " Edit", Color::Cyan));
+                    spans.push(sep());
+                    spans.extend(hint("d", " Delete", Color::Red));
+                    spans.push(sep());
+                    spans.extend(hint("Esc", " Close", Color::Red));
+                }
+                EditorInputMode::InputKey => {
+                    spans.extend(hint("0-9", " Press a key", Color::Green));
+                    spans.push(sep());
+                    spans.extend(hint("Esc", " Cancel", Color::Red));
+                }
+                EditorInputMode::InputCommand => {
+                    spans.extend(hint("Enter", " Save", Color::Green));
+                    spans.push(sep());
+                    spans.extend(hint("Esc", " Cancel", Color::Red));
+                    spans.push(sep());
+                    spans.push(Span::styled(
+                        "Type command...",
+                        Style::default().fg(Color::Rgb(80, 80, 80)),
+                    ));
+                }
+            }
         }
         Mode::AppLauncher => {
             spans.extend(hint("\u{2191}\u{2193}/jk", " Nav", Color::Yellow));
@@ -330,61 +350,155 @@ fn draw_session_picker(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_command_editor(frame: &mut Frame, app: &App, area: Rect) {
+    use crate::app::EditorInputMode;
+
     let editor = match &app.command_editor {
         Some(e) => e,
         None => return,
     };
 
     let w = 50.min(area.width.saturating_sub(4));
-    let entry_count = editor.entries.len();
-    // +3 for title border + bottom border + hint line
-    let h = ((entry_count as u16) + 4)
+    let entry_count = editor.entries.len().max(1); // at least 1 for "(no bindings)"
+                                                   // +4 for title border + bottom border + hint line + input line
+    let h = ((entry_count as u16) + 5)
         .min(area.height.saturating_sub(4))
-        .max(6);
+        .max(8);
     let x = area.x + (area.width.saturating_sub(w)) / 2;
     let y = area.y + (area.height.saturating_sub(h)) / 2;
     let popup = Rect::new(x, y, w, h);
 
     frame.render_widget(Clear, popup);
 
-    let mut items: Vec<ListItem> = editor
-        .entries
-        .iter()
-        .enumerate()
-        .map(|(i, (key, cmd))| {
-            let prefix = if i == editor.selected {
-                "\u{25b6} "
-            } else {
-                "  "
-            };
-            let style = if i == editor.selected {
+    let border_type = parse_border_type(&app.theme.border.style);
+
+    match editor.input_mode {
+        EditorInputMode::InputKey => {
+            // Show a prompt to press a key
+            let block = Block::default()
+                .title(Span::styled(
+                    " Add Binding ",
+                    Style::default().fg(Color::Green),
+                ))
+                .borders(Borders::ALL)
+                .border_type(border_type)
+                .border_style(Style::default().fg(Color::Green));
+
+            let prompt = Paragraph::new(Line::from(vec![Span::styled(
+                "Press a key (0-9):",
                 Style::default()
                     .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            ListItem::new(format!("{}{}: {}", prefix, key, cmd)).style(style)
-        })
-        .collect();
+                    .add_modifier(Modifier::BOLD),
+            )]))
+            .block(block);
 
-    if items.is_empty() {
-        items.push(ListItem::new("  (no bindings)").style(Style::default().fg(Color::DarkGray)));
+            // Use a smaller popup for the key prompt
+            let prompt_h = 3.min(popup.height);
+            let prompt_y = popup.y + (popup.height.saturating_sub(prompt_h)) / 2;
+            let prompt_area = Rect::new(popup.x, prompt_y, popup.width, prompt_h);
+            frame.render_widget(Clear, prompt_area);
+            frame.render_widget(prompt, prompt_area);
+        }
+        EditorInputMode::InputCommand => {
+            // Show existing entries + an input line at bottom
+            let key_label = editor
+                .pending_key
+                .map(|k| k.to_string())
+                .unwrap_or_default();
+
+            let mut items: Vec<ListItem> = editor
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(i, (key, cmd))| {
+                    let prefix = if i == editor.selected {
+                        "\u{25b6} "
+                    } else {
+                        "  "
+                    };
+                    let style = if i == editor.selected {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    ListItem::new(format!("{}{}: {}", prefix, key, cmd)).style(style)
+                })
+                .collect();
+
+            if items.is_empty() {
+                items.push(
+                    ListItem::new("  (no bindings)").style(Style::default().fg(Color::DarkGray)),
+                );
+            }
+
+            // Add separator and input line
+            items.push(ListItem::new(""));
+            let input_line = format!("  {}: {}\u{2588}", key_label, editor.input_buffer);
+            items.push(
+                ListItem::new(input_line).style(
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            );
+
+            let list = List::new(items).block(
+                Block::default()
+                    .title(Span::styled(
+                        " Command Bindings ",
+                        Style::default().fg(Color::Cyan),
+                    ))
+                    .borders(Borders::ALL)
+                    .border_type(border_type)
+                    .border_style(Style::default().fg(Color::Green)),
+            );
+
+            frame.render_widget(list, popup);
+        }
+        EditorInputMode::Browse => {
+            // Normal browse view
+            let mut items: Vec<ListItem> = editor
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(i, (key, cmd))| {
+                    let prefix = if i == editor.selected {
+                        "\u{25b6} "
+                    } else {
+                        "  "
+                    };
+                    let style = if i == editor.selected {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    ListItem::new(format!("{}{}: {}", prefix, key, cmd)).style(style)
+                })
+                .collect();
+
+            if items.is_empty() {
+                items.push(
+                    ListItem::new("  (no bindings)").style(Style::default().fg(Color::DarkGray)),
+                );
+            }
+
+            let list = List::new(items).block(
+                Block::default()
+                    .title(Span::styled(
+                        " Command Bindings ",
+                        Style::default().fg(Color::Cyan),
+                    ))
+                    .borders(Borders::ALL)
+                    .border_type(border_type)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            );
+
+            frame.render_widget(list, popup);
+        }
     }
-
-    let border_type = parse_border_type(&app.theme.border.style);
-    let list = List::new(items).block(
-        Block::default()
-            .title(Span::styled(
-                " Command Bindings ",
-                Style::default().fg(Color::Cyan),
-            ))
-            .borders(Borders::ALL)
-            .border_type(border_type)
-            .border_style(Style::default().fg(Color::Cyan)),
-    );
-
-    frame.render_widget(list, popup);
 }
 
 fn draw_app_launcher(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- Turns the command editor (Ctrl-E) into a full settings editor with add, edit, and delete support for command bindings
- Adds `EditorInputMode` state machine (Browse -> InputKey -> InputCommand) with text input for commands
- Persists all binding changes to `~/.config/tmuch/config.toml` via new `save_bindings()` function that preserves existing config sections
- Updates hints bar and popup UI to reflect current input mode with appropriate prompts

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes  
- [x] `cargo test` passes (27 tests)
- [x] `cargo build --release` succeeds
- [x] `bash tests/run-e2e.sh` passes (43/43 tests)
- [ ] Manual: open editor (Ctrl-E), press `a`, press a digit, type a command, press Enter — verify binding appears and persists in config.toml
- [ ] Manual: select a binding, press `e`, edit command, press Enter — verify update persists
- [ ] Manual: press Esc at any input stage — verify cancel returns to Browse mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)